### PR TITLE
Fixed Deprecation Warnings | Fixed TS bug around react types

### DIFF
--- a/components/badge/src/badge.module.scss
+++ b/components/badge/src/badge.module.scss
@@ -35,7 +35,7 @@
   }
 
   &.small {
-    font-size: size('5x') / 2;
+    font-size: size('5x') * 0.5;
   }
 
   &.large {
@@ -45,7 +45,7 @@
 
 @include media-breakpoint-down('sm') {
   .badge {
-    padding: size('small') / 2 size('2x');
+    padding: size('small') * 0.5 size('2x');
 
     @include typography('caption');
   }

--- a/components/grid/src/grid-column.module.scss
+++ b/components/grid/src/grid-column.module.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import './helper';
 
 $named-sizes: (
@@ -16,7 +18,7 @@ $named-sizes: (
 .column {
   box-sizing: border-box;
   display: block;
-  flex: 1 1 var(--column-width, #{percentage(1 / 12)});
+  flex: 1 1 var(--column-width, #{percentage(math.div(1, 12))});
   padding-right: var(--column-inset);
   padding-bottom: var(--column-gap);
   padding-left: var(--column-inset);
@@ -44,18 +46,18 @@ $named-sizes: (
 
   @for $i from 1 through 12 {
     &.is-#{$i} {
-      --column-width: #{percentage($i / 12)};
+      --column-width: #{percentage(math.div($i, 12))};
 
       flex: none;
       width: var(--column-width);
     }
 
     &.offset-#{$i} {
-      margin-left: percentage($i / 12);
+      margin-left: percentage(math.div($i, 12));
     }
 
     &.offset-right-#{$i} {
-      margin-right: percentage($i / 12);
+      margin-right: percentage(math.div($i, 12));
     }
   }
 }

--- a/components/stepper/src/small-step.module.scss
+++ b/components/stepper/src/small-step.module.scss
@@ -72,7 +72,7 @@
     flex-direction: column;
     #{ $self }__label {
       bottom: 50%;
-      left: size('3x') - (size('small') / 2);
+      left: size('3x') - (size('small') * 0.5);
       display: flex;
       margin-bottom: 0;
       background: transparent;

--- a/components/stepper/src/step.module.scss
+++ b/components/stepper/src/step.module.scss
@@ -46,13 +46,13 @@
   &__label {
     position: absolute;
     &--horizontal {
-      left: size('3x') - (size('small') / 2);
+      left: size('3x') - (size('small') * 0.5);
       padding-top: size('small');
       text-align: center;
       transform: translateX(-50%);
     }
     &--vertical {
-      top: size('3x') - (size('small') / 2);
+      top: size('3x') - (size('small') * 0.5);
       left: 100%;
       min-width: size('3x') * 10;
       padding-left: size('3x');
@@ -70,7 +70,7 @@
     position: absolute;
     left: size('5x');
     width: 15%;
-    height: size('1x') / 2;
+    height: size('1x') * 0.5;
     background: color('primary');
   }
   &__item {
@@ -88,7 +88,7 @@
       #{ $self }__half-complete {
         top: size('5x');
         left: 50%;
-        width: size('1x') / 2;
+        width: size('1x') * 0.5;
         height: 15%;
         transform: translateX(-50%);
       }

--- a/package.json
+++ b/package.json
@@ -149,6 +149,10 @@
     "webpack-filter-warnings-plugin": "^1.2.1",
     "webpackbar": "^5.0.0-3"
   },
+  "resolutions": {
+    "@types/react": "17.0.2",
+    "@types/react-dom": "17.0.2"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged ",

--- a/packages/accoutrement/src/config/colors.scss
+++ b/packages/accoutrement/src/config/colors.scss
@@ -1,12 +1,12 @@
 // - Solid Colors
 // https://zpl.io/a8w1k0d
-$-tokens-colors-primary: hsl(244, 54, 53) !default;
-$-tokens-colors-success: hsl(138, 53, 53) !default;
-$-tokens-colors-warning: hsl(40, 87, 53) !default;
-$-tokens-colors-danger: hsl(0, 54, 53) !default;
-$-tokens-colors-gray: hsl(0, 0, 90) !default;
-$-tokens-colors-brown: hsl(26, 40, 54) !default;
-$-tokens-colors-pink: hsl(346, 100, 62) !default;
+$-tokens-colors-primary: hsl(244, 54%, 53%) !default;
+$-tokens-colors-success: hsl(138, 53%, 53%) !default;
+$-tokens-colors-warning: hsl(40, 87%, 53%) !default;
+$-tokens-colors-danger: hsl(0, 54%, 53%) !default;
+$-tokens-colors-gray: hsl(0, 0%, 90%) !default;
+$-tokens-colors-brown: hsl(26, 40%, 54%) !default;
+$-tokens-colors-pink: hsl(346, 100%, 62%) !default;
 
 $brand-colors: (
   'primary': $-tokens-colors-primary,
@@ -35,7 +35,7 @@ $colors: (
   'nav-bar.item.background:active': '#primary-lighter',
   'nav-bar.item.text:active': $-tokens-colors-primary,
   'nav-bar.border': '#gray-light',
-  "nav-bar.text": #000,
+  'nav-bar.text': #000,
   'top-bar.background': '#nav-bar.background',
   'top-bar.border': '#nav-bar.border',
   'page.background': '#gray-light',

--- a/packages/uikit-design/_size.scss
+++ b/packages/uikit-design/_size.scss
@@ -1,15 +1,20 @@
+@use "sass:math";
+
 $-vertical-grid-size: 16px !default;
 
 $-sizes: () !default;
-$-sizes: merge((
-  '2xs': $-vertical-grid-size * 0.25,
-  'xs': $-vertical-grid-size * 0.5,
-  's': $-vertical-grid-size * 0.75,
-  'r': $-vertical-grid-size,
-  'l': $-vertical-grid-size * 1.25,
-  'xl': $-vertical-grid-size * 1.5,
-  '2xl': $-vertical-grid-size * 1.75,
-), $-sizes);
+$-sizes: merge(
+  (
+    '2xs': $-vertical-grid-size * 0.25,
+    'xs': $-vertical-grid-size * 0.5,
+    's': $-vertical-grid-size * 0.75,
+    'r': $-vertical-grid-size,
+    'l': $-vertical-grid-size * 1.25,
+    'xl': $-vertical-grid-size * 1.5,
+    '2xl': $-vertical-grid-size * 1.75,
+  ),
+  $-sizes
+);
 
 $-spacing: () !default;
 $-spacing: merge(
@@ -18,7 +23,6 @@ $-spacing: merge(
     'regular': $-vertical-grid-size * 1.5,
     'medium': $-vertical-grid-size * 2,
     'large': $-vertical-grid-size * 2.5,
-
     '1x': $-vertical-grid-size * 1,
     '2x': $-vertical-grid-size * 2,
     '3x': $-vertical-grid-size * 3,
@@ -32,27 +36,23 @@ $-spacing: merge(
   @return map-get-or-throw(
     $-sizes,
     $name,
-    "UIKit(size): Unknown size name: #{$name}"
+    'UIKit(size): Unknown size name: #{$name}'
   );
 }
 
 @function ui-relative-size($name: r) {
-  @return to-rem(
-    ui-size($name)
-  );
+  @return to-rem(ui-size($name));
 }
 
 @function ui-context-size($name: r) {
-  @return to-em(
-    ui-size($name)
-  );
+  @return to-em(ui-size($name));
 }
 
 @function ui-space($name: '1x') {
   @return map-get-or-throw(
     $-spacing,
     $name,
-    "UIKit(space): Unknown size name: #{$name}"
+    'UIKit(space): Unknown size name: #{$name}'
   );
 }
 
@@ -69,7 +69,7 @@ $-border-radii: merge(
   (
     small: ui-size('2xs'),
     medium: ui-size(xs),
-    large: ui-size(s)
+    large: ui-size(s),
   ),
   $-border-radii
 );
@@ -78,7 +78,7 @@ $-border-radii: merge(
   @return map-get-or-throw(
     $-border-radii,
     $size,
-    "UIKit(border-radius): Unknown size name: #{$size}"
+    'UIKit(border-radius): Unknown size name: #{$size}'
   );
 }
 
@@ -99,7 +99,7 @@ $-border-radii: merge(
     $val: strip-unit($value);
 
     @if $unit == 'px' {
-      $result: append($result, $val / $base * 1em);
+      $result: append($result, math.div($val, $base) * 1em);
     } @else if ($unit == 'em') {
       $result: append($result, $value);
     } @else {
@@ -122,7 +122,7 @@ $-border-radii: merge(
     $val: strip-unit($value);
 
     @if $unit == 'px' {
-      $result: append($result, $val / $base * 1rem);
+      $result: append($result, math.div($val, $base) * 1rem);
     } @else if ($unit == 'rem') {
       $result: append($result, $value);
     } @else {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,9 @@
 lockfileVersion: 5.3
 
+overrides:
+  '@types/react': 17.0.2
+  '@types/react-dom': 17.0.2
+
 importers:
 
   .:
@@ -229,54 +233,54 @@ importers:
       '@myntra/uikit-component-layout': 1.13.*
       '@myntra/uikit-context': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-context': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-component-layout': link:../layout
+      '@myntra/uikit-context': link:../../packages/uikit-context
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/avatar:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       name-initials: ^0.1.3
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       name-initials: 0.1.3
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/badge:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/banner:
     specifiers:
@@ -286,37 +290,37 @@ importers:
       '@myntra/uikit-component-layout': 1.13.*
       '@myntra/uikit-component-text': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-component-layout': link:../layout
+      '@myntra/uikit-component-text': link:../text
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/bread-crumb:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/button:
     specifiers:
@@ -326,21 +330,21 @@ importers:
       '@myntra/uikit-component-text': 1.13.*
       '@myntra/uikit-context': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-loader': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-context': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-component-loader': link:../loader
+      '@myntra/uikit-component-text': link:../text
+      '@myntra/uikit-context': link:../../packages/uikit-context
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/button-group:
     specifiers:
@@ -348,35 +352,35 @@ importers:
       '@myntra/uikit-component-dropdown': 1.13.*
       '@myntra/uikit-component-list': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': latest
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-dropdown': link:../dropdown
+      '@myntra/uikit-component-list': link:../list
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': registry.npmjs.org/@types/react/18.0.15
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/click-away:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/dropdown:
     specifiers:
@@ -386,41 +390,41 @@ importers:
       '@myntra/uikit-component-measure': 1.13.*
       '@myntra/uikit-component-portal': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       prop-types: ^15.7.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-click-away': 1.13.96
-      '@myntra/uikit-component-measure': 1.13.96
-      '@myntra/uikit-component-portal': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-click-away': link:../click-away
+      '@myntra/uikit-component-measure': link:../measure
+      '@myntra/uikit-component-portal': link:../portal
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       prop-types: 15.7.2
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/error-boundary:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       prop-types: ^15.7.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       prop-types: 15.7.2
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/fab:
     specifiers:
@@ -429,54 +433,54 @@ importers:
       '@myntra/uikit-component-dropdown': 1.13.*
       '@myntra/uikit-component-icon': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': latest
+      '@types/react': 17.0.2
       prop-types: ^15.7.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-dropdown': link:../dropdown
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       prop-types: 15.7.2
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': registry.npmjs.org/@types/react/18.0.15
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/field:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       prop-types: ^15.7.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       prop-types: 15.7.2
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/flex:
     specifiers:
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': latest
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': registry.npmjs.org/@types/react/18.0.15
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/form:
     specifiers:
@@ -499,75 +503,75 @@ importers:
       '@myntra/uikit-component-input-text-area': 1.13.*
       '@myntra/uikit-context': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-button-group': 1.13.96
-      '@myntra/uikit-component-field': 1.13.96
-      '@myntra/uikit-component-grid': 1.13.96
-      '@myntra/uikit-component-input-azure-file': 1.13.65
-      '@myntra/uikit-component-input-checkbox': 1.13.96
-      '@myntra/uikit-component-input-date': 1.13.96
-      '@myntra/uikit-component-input-file': 1.13.96
-      '@myntra/uikit-component-input-masked': 1.13.96
-      '@myntra/uikit-component-input-month': 1.13.96
-      '@myntra/uikit-component-input-number': 1.13.96
-      '@myntra/uikit-component-input-radio': 1.13.96
-      '@myntra/uikit-component-input-s3-file': 1.13.96
-      '@myntra/uikit-component-input-select': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-component-input-text-area': 1.13.96
-      '@myntra/uikit-context': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-button-group': link:../button-group
+      '@myntra/uikit-component-field': link:../field
+      '@myntra/uikit-component-grid': link:../grid
+      '@myntra/uikit-component-input-azure-file': link:../input-azure-file
+      '@myntra/uikit-component-input-checkbox': link:../input-checkbox
+      '@myntra/uikit-component-input-date': link:../input-date
+      '@myntra/uikit-component-input-file': link:../input-file
+      '@myntra/uikit-component-input-masked': link:../input-masked
+      '@myntra/uikit-component-input-month': link:../input-month
+      '@myntra/uikit-component-input-number': link:../input-number
+      '@myntra/uikit-component-input-radio': link:../input-radio
+      '@myntra/uikit-component-input-s3-file': link:../input-s3-file
+      '@myntra/uikit-component-input-select': link:../input-select
+      '@myntra/uikit-component-input-text': link:../input-text
+      '@myntra/uikit-component-input-text-area': link:../input-text-area
+      '@myntra/uikit-context': link:../../packages/uikit-context
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/grid:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       prop-types: ^15.7.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       prop-types: 15.7.2
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/group:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/icon:
     specifiers:
       '@myntra/svg': 1.13.*
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       '@znck/promised': ^1.0.4
       glob: ^7.1.3
       lodash.camelcase: ^4.3.0
@@ -575,14 +579,14 @@ importers:
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
       react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@myntra/svg': 1.13.96
-      '@types/react': 16.14.20
+      '@myntra/svg': link:../../packages/svg
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
       '@znck/promised': 1.0.4
       glob: 7.2.0
       lodash.camelcase: 4.3.0
@@ -592,21 +596,21 @@ importers:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       intersection-observer-polyfill: ^0.1.0
       prop-types: ^15.7.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       intersection-observer-polyfill: 0.1.0
       prop-types: 15.7.2
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-azure-file:
     specifiers:
@@ -614,37 +618,37 @@ importers:
       '@myntra/uikit-component-input-file': 1.13.*
       '@myntra/uikit-component-progress': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-input-file': 1.13.96
-      '@myntra/uikit-component-progress': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-input-file': link:../input-file
+      '@myntra/uikit-component-progress': link:../progress
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-checkbox:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-input-text': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-input-text': link:../input-text
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-date:
     specifiers:
@@ -658,65 +662,65 @@ importers:
       '@myntra/uikit-component-input-text': 1.13.*
       '@myntra/uikit-component-layout': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       date-fns: ^2.0.0-alpha.27
       dayjs: ^1.8.14
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-button-group': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-input-masked': 1.13.96
-      '@myntra/uikit-component-input-number': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-button-group': link:../button-group
+      '@myntra/uikit-component-dropdown': link:../dropdown
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-component-input-masked': link:../input-masked
+      '@myntra/uikit-component-input-number': link:../input-number
+      '@myntra/uikit-component-input-text': link:../input-text
+      '@myntra/uikit-component-layout': link:../layout
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       date-fns: 2.25.0
       dayjs: 1.10.7
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-file:
     specifiers:
       '@myntra/uikit-component-button': 1.13.*
       '@myntra/uikit-component-input-text': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': latest
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-input-text': link:../input-text
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': registry.npmjs.org/@types/react/18.0.15
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-masked:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-input-text': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-input-text': link:../input-text
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-month:
     specifiers:
@@ -725,56 +729,56 @@ importers:
       '@myntra/uikit-component-input-date': 1.13.*
       '@myntra/uikit-component-input-masked': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       luxon: ^1.21.1
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-input-date': 1.13.96
-      '@myntra/uikit-component-input-masked': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-dropdown': link:../dropdown
+      '@myntra/uikit-component-input-date': link:../input-date
+      '@myntra/uikit-component-input-masked': link:../input-masked
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       luxon: 1.28.0
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-number:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-input-text': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-input-text': link:../input-text
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-radio:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-s3-file:
     specifiers:
@@ -783,20 +787,20 @@ importers:
       '@myntra/uikit-component-input-file': 1.13.*
       '@myntra/uikit-component-progress': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-input-file': 1.13.96
-      '@myntra/uikit-component-progress': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-input-file': link:../input-file
+      '@myntra/uikit-component-progress': link:../progress
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-select:
     specifiers:
@@ -806,59 +810,59 @@ importers:
       '@myntra/uikit-component-input-text': 1.13.*
       '@myntra/uikit-component-list': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       sifter: ^0.5.3
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-component-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-dropdown': link:../dropdown
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-component-input-text': link:../input-text
+      '@myntra/uikit-component-list': link:../list
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       sifter: 0.5.4
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-text:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-icon': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/input-text-area:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-input-text': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-input-text': link:../input-text
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/job-tracker:
     specifiers:
@@ -870,39 +874,39 @@ importers:
       '@myntra/uikit-component-loader': 1.13.*
       '@myntra/uikit-component-text': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       dayjs: ^1.8.14
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-grid': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-component-loader': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-grid': link:../grid
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-component-layout': link:../layout
+      '@myntra/uikit-component-loader': link:../loader
+      '@myntra/uikit-component-text': link:../text
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       dayjs: 1.10.7
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/layout:
     specifiers:
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': latest
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': registry.npmjs.org/@types/react/18.0.15
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/list:
     specifiers:
@@ -910,59 +914,59 @@ importers:
       '@myntra/uikit-component-input-checkbox': 1.13.*
       '@myntra/uikit-component-virtual-list': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       scroll-into-view-if-needed: ^2.2.20
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-input-checkbox': 1.13.96
-      '@myntra/uikit-component-virtual-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-input-checkbox': link:../input-checkbox
+      '@myntra/uikit-component-virtual-list': link:../virtual-list
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       scroll-into-view-if-needed: 2.2.28
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
       react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/loader:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/measure:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       prop-types: ^15.7.2
       react: '>=15.4'
       react-dom: ^16.8.6
       resize-observer-polyfill: ^1.5.1
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       prop-types: 15.7.2
       resize-observer-polyfill: 1.5.1
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 16.14.0_react@17.0.2
+      react: registry.npmjs.org/react/17.0.2
+      react-dom: registry.npmjs.org/react-dom/16.14.0_react@17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/modal:
     specifiers:
@@ -970,19 +974,19 @@ importers:
       '@myntra/uikit-component-button': 1.13.*
       '@myntra/uikit-component-portal': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-portal': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-portal': link:../portal
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/nav-bar:
     specifiers:
@@ -992,21 +996,21 @@ importers:
       '@myntra/uikit-component-icon': 1.13.*
       '@myntra/uikit-context': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-avatar': 1.13.96
-      '@myntra/uikit-component-click-away': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-context': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-avatar': link:../avatar
+      '@myntra/uikit-component-click-away': link:../click-away
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-context': link:../../packages/uikit-context
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/notification:
     specifiers:
@@ -1014,91 +1018,91 @@ importers:
       '@myntra/uikit-component-button': 1.13.*
       '@myntra/uikit-component-section': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-section': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-section': link:../section
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/page:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/pagination:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-icon': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/portal:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       prop-types: ^15.7.2
       react: '>=15.4'
       react-dom: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       prop-types: 15.7.2
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
+      react: registry.npmjs.org/react/17.0.2
+      react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/progress:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-text': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-text': link:../text
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/schema-form:
     specifiers:
@@ -1108,39 +1112,39 @@ importers:
       '@myntra/uikit-component-form': 1.13.*
       '@myntra/uikit-component-grid': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-field': 1.13.96
-      '@myntra/uikit-component-form': 1.13.96
-      '@myntra/uikit-component-grid': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-field': link:../field
+      '@myntra/uikit-component-form': link:../form
+      '@myntra/uikit-component-grid': link:../grid
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/section:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-button': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/stepper:
     specifiers:
@@ -1149,22 +1153,22 @@ importers:
       '@myntra/uikit-component-layout': 1.13.*
       '@myntra/uikit-component-text': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': latest
+      '@types/react': 17.0.2
       prop-types: ^15.7.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-component-layout': link:../layout
+      '@myntra/uikit-component-text': link:../text
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       prop-types: 15.7.2
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': registry.npmjs.org/@types/react/18.0.15
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/table:
     specifiers:
@@ -1180,75 +1184,75 @@ importers:
       '@myntra/uikit-component-virtual-list': 1.13.*
       '@myntra/uikit-context': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-field': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-component-list': 1.13.96
-      '@myntra/uikit-component-measure': 1.13.96
-      '@myntra/uikit-component-virtual-grid': 1.13.96
-      '@myntra/uikit-component-virtual-list': 1.13.96
-      '@myntra/uikit-context': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-button': link:../button
+      '@myntra/uikit-component-dropdown': link:../dropdown
+      '@myntra/uikit-component-field': link:../field
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-component-input-text': link:../input-text
+      '@myntra/uikit-component-list': link:../list
+      '@myntra/uikit-component-measure': link:../measure
+      '@myntra/uikit-component-virtual-grid': link:../virtual-grid
+      '@myntra/uikit-component-virtual-list': link:../virtual-list
+      '@myntra/uikit-context': link:../../packages/uikit-context
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/tabs:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/text:
     specifiers:
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8.23
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/tooltip:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-dropdown': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-dropdown': link:../dropdown
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
       react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/top-bar:
     specifiers:
@@ -1258,61 +1262,61 @@ importers:
       '@myntra/uikit-component-icon': 1.13.*
       '@myntra/uikit-component-list': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-bread-crumb': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-bread-crumb': link:../bread-crumb
+      '@myntra/uikit-component-dropdown': link:../dropdown
+      '@myntra/uikit-component-icon': link:../icon
+      '@myntra/uikit-component-list': link:../list
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/virtual-grid:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-virtual-list': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
+      '@types/react': 17.0.2
       react: '>=15.4'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-virtual-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-virtual-list': link:../virtual-list
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   components/virtual-list:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
       '@myntra/uikit-component-measure': 1.13.*
       '@myntra/uikit-utils': 1.13.*
-      '@types/react': ^16.8
-      '@types/react-dom': ^16.8.3
+      '@types/react': 17.0.2
+      '@types/react-dom': 17.0.2
       react: '>=15.4'
       react-dom: '>=16.0'
       uikit-icons: npm:@myntra/uikit-icons@latest
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-measure': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-can-i-use': link:../../packages/uikit-can-i-use
+      '@myntra/uikit-component-measure': link:../measure
+      '@myntra/uikit-utils': link:../../packages/uikit-utils
       uikit-icons: /@myntra/uikit-icons/1.0.31
     optionalDependencies:
-      react: 17.0.2
+      react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     devDependencies:
-      '@types/react': 16.14.20
-      '@types/react-dom': 16.9.14
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
+      '@types/react-dom': registry.npmjs.org/@types/react-dom/17.0.2
 
   packages/accoutrement:
     specifiers:
@@ -1327,7 +1331,7 @@ importers:
       '@myntra/uikit-utils': 1.13.*
       loader-utils: ^1.1.0
     dependencies:
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/uikit-utils': link:../uikit-utils
       loader-utils: 1.4.0
 
   packages/codemod-utils:
@@ -1341,7 +1345,7 @@ importers:
       jsdoc-api: ^4.0.3
       prettier: ^1.13.4
     dependencies:
-      '@myntra/eslint-config-standard': 1.13.96
+      '@myntra/eslint-config-standard': link:../eslint-config-standard
       debug: 3.2.7
       eslint: 4.19.1
       execa: 0.10.0
@@ -1444,7 +1448,7 @@ importers:
       stylelint-config-standard: 18.3.0_stylelint@10.1.0
       stylelint-scss: 3.21.0_stylelint@10.1.0
     optionalDependencies:
-      stylelint: 10.1.0
+      stylelint: registry.npmjs.org/stylelint/10.1.0
 
   packages/svg:
     specifiers:
@@ -1528,60 +1532,60 @@ importers:
       print-message: ^3.0.1
       sass: ^1.26.5
     dependencies:
-      '@myntra/accoutrement': 1.13.96
-      '@myntra/uikit-component-accordion': 1.13.96
-      '@myntra/uikit-component-avatar': 1.13.96
-      '@myntra/uikit-component-badge': 1.13.96
-      '@myntra/uikit-component-banner': 1.13.96
-      '@myntra/uikit-component-bread-crumb': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-button-group': 1.13.96
-      '@myntra/uikit-component-click-away': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-error-boundary': 1.13.96
-      '@myntra/uikit-component-fab': 1.13.96
-      '@myntra/uikit-component-field': 1.13.96
-      '@myntra/uikit-component-flex': 1.13.96
-      '@myntra/uikit-component-form': 1.13.96
-      '@myntra/uikit-component-grid': 1.13.96
-      '@myntra/uikit-component-group': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-image': 1.13.96
-      '@myntra/uikit-component-input-azure-file': 1.13.65
-      '@myntra/uikit-component-input-checkbox': 1.13.96
-      '@myntra/uikit-component-input-date': 1.13.96
-      '@myntra/uikit-component-input-file': 1.13.96
-      '@myntra/uikit-component-input-masked': 1.13.96
-      '@myntra/uikit-component-input-month': 1.13.96
-      '@myntra/uikit-component-input-number': 1.13.96
-      '@myntra/uikit-component-input-radio': 1.13.96
-      '@myntra/uikit-component-input-s3-file': 1.13.96
-      '@myntra/uikit-component-input-select': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-component-input-text-area': 1.13.96
-      '@myntra/uikit-component-job-tracker': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-component-list': 1.13.96
-      '@myntra/uikit-component-loader': 1.13.96
-      '@myntra/uikit-component-measure': 1.13.96
-      '@myntra/uikit-component-modal': 1.13.96
-      '@myntra/uikit-component-nav-bar': 1.13.96
-      '@myntra/uikit-component-notification': 1.13.96
-      '@myntra/uikit-component-page': 1.13.96
-      '@myntra/uikit-component-pagination': 1.13.96
-      '@myntra/uikit-component-portal': 1.13.96
-      '@myntra/uikit-component-progress': 1.13.96
-      '@myntra/uikit-component-schema-form': 1.13.96
-      '@myntra/uikit-component-section': 1.13.96
-      '@myntra/uikit-component-stepper': 1.13.96
-      '@myntra/uikit-component-table': 1.13.96
-      '@myntra/uikit-component-tabs': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-component-tooltip': 1.13.96
-      '@myntra/uikit-component-top-bar': 1.13.96
-      '@myntra/uikit-component-virtual-grid': 1.13.96
-      '@myntra/uikit-component-virtual-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
+      '@myntra/accoutrement': link:../accoutrement
+      '@myntra/uikit-component-accordion': link:../../components/accordion
+      '@myntra/uikit-component-avatar': link:../../components/avatar
+      '@myntra/uikit-component-badge': link:../../components/badge
+      '@myntra/uikit-component-banner': link:../../components/banner
+      '@myntra/uikit-component-bread-crumb': link:../../components/bread-crumb
+      '@myntra/uikit-component-button': link:../../components/button
+      '@myntra/uikit-component-button-group': link:../../components/button-group
+      '@myntra/uikit-component-click-away': link:../../components/click-away
+      '@myntra/uikit-component-dropdown': link:../../components/dropdown
+      '@myntra/uikit-component-error-boundary': link:../../components/error-boundary
+      '@myntra/uikit-component-fab': link:../../components/fab
+      '@myntra/uikit-component-field': link:../../components/field
+      '@myntra/uikit-component-flex': link:../../components/flex
+      '@myntra/uikit-component-form': link:../../components/form
+      '@myntra/uikit-component-grid': link:../../components/grid
+      '@myntra/uikit-component-group': link:../../components/group
+      '@myntra/uikit-component-icon': link:../../components/icon
+      '@myntra/uikit-component-image': link:../../components/image
+      '@myntra/uikit-component-input-azure-file': link:../../components/input-azure-file
+      '@myntra/uikit-component-input-checkbox': link:../../components/input-checkbox
+      '@myntra/uikit-component-input-date': link:../../components/input-date
+      '@myntra/uikit-component-input-file': link:../../components/input-file
+      '@myntra/uikit-component-input-masked': link:../../components/input-masked
+      '@myntra/uikit-component-input-month': link:../../components/input-month
+      '@myntra/uikit-component-input-number': link:../../components/input-number
+      '@myntra/uikit-component-input-radio': link:../../components/input-radio
+      '@myntra/uikit-component-input-s3-file': link:../../components/input-s3-file
+      '@myntra/uikit-component-input-select': link:../../components/input-select
+      '@myntra/uikit-component-input-text': link:../../components/input-text
+      '@myntra/uikit-component-input-text-area': link:../../components/input-text-area
+      '@myntra/uikit-component-job-tracker': link:../../components/job-tracker
+      '@myntra/uikit-component-layout': link:../../components/layout
+      '@myntra/uikit-component-list': link:../../components/list
+      '@myntra/uikit-component-loader': link:../../components/loader
+      '@myntra/uikit-component-measure': link:../../components/measure
+      '@myntra/uikit-component-modal': link:../../components/modal
+      '@myntra/uikit-component-nav-bar': link:../../components/nav-bar
+      '@myntra/uikit-component-notification': link:../../components/notification
+      '@myntra/uikit-component-page': link:../../components/page
+      '@myntra/uikit-component-pagination': link:../../components/pagination
+      '@myntra/uikit-component-portal': link:../../components/portal
+      '@myntra/uikit-component-progress': link:../../components/progress
+      '@myntra/uikit-component-schema-form': link:../../components/schema-form
+      '@myntra/uikit-component-section': link:../../components/section
+      '@myntra/uikit-component-stepper': link:../../components/stepper
+      '@myntra/uikit-component-table': link:../../components/table
+      '@myntra/uikit-component-tabs': link:../../components/tabs
+      '@myntra/uikit-component-text': link:../../components/text
+      '@myntra/uikit-component-tooltip': link:../../components/tooltip
+      '@myntra/uikit-component-top-bar': link:../../components/top-bar
+      '@myntra/uikit-component-virtual-grid': link:../../components/virtual-grid
+      '@myntra/uikit-component-virtual-list': link:../../components/virtual-list
+      '@myntra/uikit-utils': link:../uikit-utils
       normalize.css: 8.0.1
       print-message: 3.0.1
     devDependencies:
@@ -1589,16 +1593,16 @@ importers:
 
   packages/uikit-can-i-use:
     specifiers:
-      '@types/react': ^16.8.23
-      '@types/react-dom': ^16.8.4
+      '@types/react': 17.0.2
+      '@types/react-dom': 17.0.2
       react: '*'
       react-dom: '*'
     optionalDependencies:
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     devDependencies:
-      '@types/react': 16.14.20
-      '@types/react-dom': 16.9.14
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
+      '@types/react-dom': registry.npmjs.org/@types/react-dom/17.0.2
 
   packages/uikit-cli:
     specifiers:
@@ -1628,7 +1632,7 @@ importers:
       semver: ^7.1.3
       typescript: ^3.8.3
     dependencies:
-      '@myntra/eslint-config-standard': 1.13.96
+      '@myntra/eslint-config-standard': link:../eslint-config-standard
       '@znck/promised': 1.0.4
       babel-preset-es2015: 6.24.1
       babel-preset-stage-0: 6.24.1
@@ -1658,25 +1662,25 @@ importers:
   packages/uikit-context:
     specifiers:
       '@myntra/uikit-can-i-use': 1.13.*
-      '@types/react': ^16.8.10
+      '@types/react': 17.0.2
       react: ^16.8.4
     dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
+      '@myntra/uikit-can-i-use': link:../uikit-can-i-use
       react: 16.14.0
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   packages/uikit-design:
     specifiers: {}
 
   packages/uikit-utils:
     specifiers:
-      '@types/react': ^16.8.24
+      '@types/react': 17.0.2
       react: ^16.0.0
     optionalDependencies:
       react: registry.npmjs.org/react/16.14.0
     devDependencies:
-      '@types/react': 16.14.20
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
 
   themes/nuclei:
     specifiers:
@@ -1685,11 +1689,11 @@ importers:
       '@myntra/uikit': 1.13.*
       '@myntra/uikit-design': 1.13.*
     dependencies:
-      '@myntra/uikit': 1.13.96
+      '@myntra/uikit': link:../../packages/uikit
     devDependencies:
-      '@myntra/accoutrement': 1.13.96
-      '@myntra/tokenizer': 1.13.96
-      '@myntra/uikit-design': 1.13.96
+      '@myntra/accoutrement': link:../../packages/accoutrement
+      '@myntra/tokenizer': link:../../packages/tokenizer
+      '@myntra/uikit-design': link:../../packages/uikit-design
 
   themes/unity:
     specifiers:
@@ -1698,11 +1702,11 @@ importers:
       '@myntra/uikit': 1.13.*
       '@myntra/uikit-design': 1.13.*
     dependencies:
-      '@myntra/uikit': 1.13.96
+      '@myntra/uikit': link:../../packages/uikit
     devDependencies:
-      '@myntra/accoutrement': 1.13.96
-      '@myntra/tokenizer': 1.13.96
-      '@myntra/uikit-design': 1.13.96
+      '@myntra/accoutrement': link:../../packages/accoutrement
+      '@myntra/tokenizer': link:../../packages/tokenizer
+      '@myntra/uikit-design': link:../../packages/uikit-design
 
 packages:
 
@@ -3258,787 +3262,11 @@ packages:
       call-me-maybe: 1.0.1
       glob-to-regexp: 0.3.0
 
-  /@myntra/accoutrement/1.13.96:
-    resolution: {integrity: sha512-/XN3uYCzvzI3RJspHj9NWppMwmwsek3JvHqSZVPtFvoInxaLd3ceXGcpMVAICip65sVBG2WbiMaT5gqXOKpuuA==}
-    dependencies:
-      accoutrement: registry.npmjs.org/accoutrement/2.2.0
-      normalize.css: registry.npmjs.org/normalize.css/8.0.1
-
-  /@myntra/eslint-config-standard/1.13.96:
-    resolution: {integrity: sha512-RphOYDU4QBUcHVDxbxCcUDoSw4zl9RlTOZOtO0oH7vi+9T7SfimU0DlmK2KdIeLxzxEw0E8LK7OfK22ytu0Akg==}
-    dependencies:
-      babel-eslint: registry.npmjs.org/babel-eslint/8.2.6
-      babel-plugin-syntax-jsx: registry.npmjs.org/babel-plugin-syntax-jsx/6.18.0
-      eslint-config-prettier: registry.npmjs.org/eslint-config-prettier/2.10.0_eslint@8.1.0
-      eslint-config-standard: registry.npmjs.org/eslint-config-standard/11.0.0_b5bc100c81ef684327d30b90513037eb
-      eslint-plugin-babel: registry.npmjs.org/eslint-plugin-babel/5.3.1_eslint@8.1.0
-      eslint-plugin-import: registry.npmjs.org/eslint-plugin-import/2.25.2_eslint@8.1.0
-      eslint-plugin-jest: registry.npmjs.org/eslint-plugin-jest/21.27.2_eslint@8.1.0
-      eslint-plugin-json: registry.npmjs.org/eslint-plugin-json/1.4.0
-      eslint-plugin-jsx-a11y: registry.npmjs.org/eslint-plugin-jsx-a11y/6.4.1_eslint@8.1.0
-      eslint-plugin-node: registry.npmjs.org/eslint-plugin-node/6.0.1_eslint@8.1.0
-      eslint-plugin-prettier: registry.npmjs.org/eslint-plugin-prettier/2.7.0_prettier@1.19.1
-      eslint-plugin-promise: registry.npmjs.org/eslint-plugin-promise/3.8.0
-      eslint-plugin-react: registry.npmjs.org/eslint-plugin-react/7.26.1_eslint@8.1.0
-      eslint-plugin-standard: registry.npmjs.org/eslint-plugin-standard/3.1.0_eslint@8.1.0
-      prettier: registry.npmjs.org/prettier/1.19.1
-    optionalDependencies:
-      eslint: registry.npmjs.org/eslint/8.1.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@myntra/svg/1.13.96:
-    resolution: {integrity: sha512-u50jXkZ2UXdQ1n9VdwhQZJUjhrV3oezOGMHYVnmA5VBNvN+PjxzoBLsuHavX8FvtYqwjGl/0xlD5Xrn9UPF2cg==}
-    dependencies:
-      svg-parser: registry.npmjs.org/svg-parser/1.0.6
-    dev: true
-
-  /@myntra/tokenizer/1.13.96:
-    resolution: {integrity: sha512-GWm4u/1iu/4FEg35N32C5gzWKJeDD8AfK3SE9UZ46T0+gCEszwsDTs4EtiJXiTOeeHfVuwUYa1bejEQnsFIFIg==}
-    hasBin: true
-    dependencies:
-      ajv: registry.npmjs.org/ajv/6.12.6
-      camelcase: registry.npmjs.org/camelcase/5.3.1
-      js-yaml: registry.npmjs.org/js-yaml/3.14.1
-      lodash.isplainobject: registry.npmjs.org/lodash.isplainobject/4.0.6
-      prettier: registry.npmjs.org/prettier/1.19.1
-      tidify: registry.npmjs.org/tidify/0.3.0
-    dev: true
-
-  /@myntra/uikit-can-i-use/1.13.96:
-    resolution: {integrity: sha512-46q1tHG1oefgbmOT7WJZLQjpHtrSLKRaS12bMxK9eK0Au/6LCj2iuxWpSFUXo3HpPagIVOVCYXO+h6pm/Z2/5A==}
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-      react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
-    dev: false
-
-  /@myntra/uikit-component-accordion/1.13.96:
-    resolution: {integrity: sha512-9wGFEzDL0xXPkNMDyt6pCDOFeIAIGfk9rxKtM3tpo+squ9gFiuNGS69E/zb+F0o71cUsh/FGbRBjN1uacd5zmw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-context': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-avatar/1.13.96:
-    resolution: {integrity: sha512-R3N/9Kl98cB8kU55UVEkhwOVVqsRWIOMYYaYfKZFOovpqSTaClj6rxbN7O5w7L2hPMKNe/7/LUhE1taI3ThTKA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      name-initials: registry.npmjs.org/name-initials/0.1.3
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-badge/1.13.96:
-    resolution: {integrity: sha512-lbG6XR8J5nK2NbOF99c+oZ2z+4LmO3UEWogqCBIjgjGgYIU+1R6LkKrNSvVKlf7jJ8DUFsYmA3DgCAT0L73+9g==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-banner/1.13.96:
-    resolution: {integrity: sha512-Se76xL56oTgViUhdZD9ckK1ORbY8zI0STw/qI613/0bV7Pc+JvO+Bgju1bV8R6rVQDPf1UxdtqTSUztSGQLTcQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-bread-crumb/1.13.96:
-    resolution: {integrity: sha512-tWP1Z+3M5ZUwfRKgBfsWVY5KHiGplMzuaAIrvbpDHV61KGlpcD2fop/11kWMl0kFlgE3GSwU39ey1MFCfj0pyQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-button-group/1.13.96:
-    resolution: {integrity: sha512-lErzgBFGU0aijrJSaEgKg3dpOBhnYB919ZOfQtzssGbphCBylb0AsJ+A6VFquRFja7PzEu2fn/VOvWzH9ix2xA==}
-    dependencies:
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-button/1.13.96:
-    resolution: {integrity: sha512-CDz9riSF6pHO8moZU6RcTDBGnoivduVTvZ5IenMoYgcss/n2bUcmZlEBtgTZKx8XoD9076ffIUXkwnd5BEKhow==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-loader': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-context': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-click-away/1.13.96:
-    resolution: {integrity: sha512-/j2UyWUy8iiYyneYQ1P/NWP4X9Asp0jusMZznRSk40ZRWxCBMNtim+x7rPaykT+fPCtnsdxO0hEedYYlskskjA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-dropdown/1.13.96:
-    resolution: {integrity: sha512-miOoJF6DDZQnz+OiHmW/Oms8vHQKaz5TIY5YlWGgKnUhRy1E4xaBrpG+HzTGDOZB6Mv5GPTUix73KZKWYaUJTA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-click-away': 1.13.96
-      '@myntra/uikit-component-measure': 1.13.96
-      '@myntra/uikit-component-portal': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      prop-types: registry.npmjs.org/prop-types/15.8.1
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-error-boundary/1.13.96:
-    resolution: {integrity: sha512-32RYIdLgV+dCdCx/KhKffLyB2FfLPl8SYWg5foU9LHVxVzJP1rjd86UcLAuWDqNyLvwFutLBDE0TSs7YRpZK/Q==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      prop-types: registry.npmjs.org/prop-types/15.8.1
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-fab/1.13.96:
-    resolution: {integrity: sha512-Oh+cEwELK5oYBfa26RTA44FgcGawhTVoJlhjiRBYJpELvTYP7QJO/6KMhNQ0gWazHBP1gci/9XoTDWKFC/wgNg==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      prop-types: registry.npmjs.org/prop-types/15.8.1
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-field/1.13.96:
-    resolution: {integrity: sha512-wgt5nOd2VFw8EFplyjtEr9fcgc5fPx9Sn1K9RU/TpZJ1S9gsVh/T5csM/m4E55e9+FxXY07b2Zrqy/hXYomPqw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      prop-types: registry.npmjs.org/prop-types/15.8.1
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-flex/1.13.96:
-    resolution: {integrity: sha512-E4qwqzXNzxeJ5nQNHHcVRxU/E5KlMjIn55aJQtTtSspZ2e0vfWHd8Zi6hS50oBzD+D+wT2syRcIug2ar7EkmYw==}
-    dependencies:
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-form/1.13.96:
-    resolution: {integrity: sha512-xYTTwKoRuhYDsSo+gUMDzhmp8wNydxUHBuexTU6VfQkiJrl2H5PqPDl05GNXIqnk9gsD3vd58GO6vMWm3SrS/g==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-button-group': 1.13.96
-      '@myntra/uikit-component-field': 1.13.96
-      '@myntra/uikit-component-grid': 1.13.96
-      '@myntra/uikit-component-input-azure-file': 1.13.65
-      '@myntra/uikit-component-input-checkbox': 1.13.96
-      '@myntra/uikit-component-input-date': 1.13.96
-      '@myntra/uikit-component-input-file': 1.13.96
-      '@myntra/uikit-component-input-masked': 1.13.96
-      '@myntra/uikit-component-input-month': 1.13.96
-      '@myntra/uikit-component-input-number': 1.13.96
-      '@myntra/uikit-component-input-radio': 1.13.96
-      '@myntra/uikit-component-input-s3-file': 1.13.96
-      '@myntra/uikit-component-input-select': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-component-input-text-area': 1.13.96
-      '@myntra/uikit-context': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-grid/1.13.96:
-    resolution: {integrity: sha512-TevXJepMDmTg5YzlPYEj462XUHaI8A0VlYer9BWGKCuYehB+XUN6maQ1xT5NDIujWvVUW4f6fl81scZd308oKQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      prop-types: registry.npmjs.org/prop-types/15.8.1
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-group/1.13.96:
-    resolution: {integrity: sha512-estOavG2YGgWfyQsyKtqsFbgXqF5tNk1OgBXkQU8/NKAEQKljd3NinHtFk2TMvjyQ7goSdkf3E1V10g/a3vIuQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-icon/1.13.96:
-    resolution: {integrity: sha512-7t7ySnzLEJM/GPd7Cwt/o1BPD9vPAyLLy0W5VwC902PLVUu7O05eVwdAyNvqE0RHvcZGXOy+EZV+o5fgP7QFrw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-image/1.13.96:
-    resolution: {integrity: sha512-lcopNolnJiT7D6OwTzpzDTRHOZqVLy1oTVVIAfphmEQUXlLB8oGXytWar3Dx7Vvat2WOainDKVKWvpQTXqkZ6Q==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      intersection-observer-polyfill: registry.npmjs.org/intersection-observer-polyfill/0.1.0
-      prop-types: registry.npmjs.org/prop-types/15.8.1
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-azure-file/1.13.65:
-    resolution: {integrity: sha512-5B7KXKJBwmryz+jnWk8IuwQbi9+Prjdf/NaP7sONtiTwBVdpxKkEGDRlQJoSg7HDCi48igUz51XFtbwVD4gUgQ==}
-    dependencies:
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-input-file': 1.13.96
-      '@myntra/uikit-component-progress': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-checkbox/1.13.96:
-    resolution: {integrity: sha512-/+cv9LZf84RWVpV8pyfInRA7ZYoiu7umKLrdI8rfpqr54oEwEPEzXXgTiiuCNSyZdWbCUtYJW8OZRV8pTsgiVw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-date/1.13.96:
-    resolution: {integrity: sha512-ENC6hDfCNdK9adaRxtViQWlz9x4vPEzfvaeoEgNcYIrGWy7Tl11E2pTjc+cFGuz05RJJODnVmHqI0TS39QCjKA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-button-group': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-input-masked': 1.13.96
-      '@myntra/uikit-component-input-number': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      date-fns: registry.npmjs.org/date-fns/2.25.0
-      dayjs: registry.npmjs.org/dayjs/1.10.7
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-file/1.13.96:
-    resolution: {integrity: sha512-nPpmpW22Febbw4u0sqISvpheZAGK7QVe76u07qFFP8ggB+d02Qa2XGay0hzKhqKz1Gvi4E+PU2uraI2cU7gpvw==}
-    dependencies:
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-masked/1.13.96:
-    resolution: {integrity: sha512-gDfFu11c7MXNVF0I0aJL8uXjND4W4LitxUcWs+qAYSZ2A2GOrNQO48BOPPc2H3vvjS47iVqd1z8PrE9v/Q4kCw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-month/1.13.96:
-    resolution: {integrity: sha512-bFEmY85tdKz0spzaFLcmX54PjBu7uYmzte81ys2+0l1srGlHrP6yhEWQt65KDIQNaMU1FTevaqfCgRenD/NU+Q==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-input-date': 1.13.96
-      '@myntra/uikit-component-input-masked': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      luxon: registry.npmjs.org/luxon/1.28.0
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-number/1.13.96:
-    resolution: {integrity: sha512-JxE9e3y3JlLroX8Pg4O4RrAAK9oAzWo10U3/viTmprzdQ9maaES1GrbNzxW15wlrHDxzC+i8olKeBCG+/O1LEg==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-radio/1.13.96:
-    resolution: {integrity: sha512-BpPd6cak/rVFjtvTehxdPDJ1aEERpaWjusf2Hs2fFlczF3W7WmoQagG+sfVCkuwdyn5JN+5Y9bCwkHSZkFz0zw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-s3-file/1.13.96:
-    resolution: {integrity: sha512-qQ7TAI4tLGbVCHEv7GHPjhkpjv3fTHHsQqsIhKuUZi8NJAJqVqmaqTYQX2xWJ3BioSzMlLuQnxiJnT0jB9G1cA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-input-file': 1.13.96
-      '@myntra/uikit-component-progress': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-select/1.13.96:
-    resolution: {integrity: sha512-MaPtiNxbAszvooAFjJSSbnMqFdbTncsyfg5gjfF/ARJqFscKWQOJ6Gd5xhDhAWntcLYQRXYwgto8925p+Y1EoA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-component-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      sifter: registry.npmjs.org/sifter/0.5.4
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-text-area/1.13.96:
-    resolution: {integrity: sha512-zFUQhVMWAsQNu3RZUUEsXibWyc6dBta9zeBD2hbonh/KwYqRKzu5z5SrFYTQ9frfKrYC7VWIV9pxFo9gL/e8qw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-input-text/1.13.96:
-    resolution: {integrity: sha512-3l/GBi8Cg7sxMqW5GRM/XCPum8ADoRVfKW+HoFcWvFfJaY7SGaaMgYUsnvPEtM/UliGTT2GgjEIpk1h4NPFwgw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-job-tracker/1.13.96:
-    resolution: {integrity: sha512-Ausn7MS4wC6Ytpr9+M3l7QhfGg+7WYmDNgElExNQxQR8F3vZK/pUQnowe9IwMRQb6kxpzUfr52mEdB+7a4AD4Q==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-grid': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-component-loader': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      dayjs: registry.npmjs.org/dayjs/1.10.7
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-layout/1.13.96:
-    resolution: {integrity: sha512-+ji1iChRKdeT+iC2VEeG2RZVU7RsW4g7/+4LFkV9KGf1cZ8OIhNH7pR7XGmZL1h8xmdhnu0QiQWbHuNpAubnxA==}
-    dependencies:
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-list/1.13.96:
-    resolution: {integrity: sha512-FsO1XToZidbLKjb2S2rElhM++CklUjwVdEx4PtKLa6R6qI7YvwaALfz3UVcwDBIdtCNGld1QkFI+XfOPU2DN4Q==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-input-checkbox': 1.13.96
-      '@myntra/uikit-component-virtual-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      scroll-into-view-if-needed: registry.npmjs.org/scroll-into-view-if-needed/2.2.28
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-loader/1.13.96:
-    resolution: {integrity: sha512-c9uM0U841gAcNcPApEFAH8N+8l/tE6g28cP/3iKXI7xBnbj3K8D9ggsMn7lv/lUBiqmtHyo7wKwm6guLQuxPeQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-measure/1.13.96:
-    resolution: {integrity: sha512-LFM442qoASAMF49zfPmmq4Ubv9Py6cxRtzrHUS5Z+2dTF5TnFREehXqCs9/YvwYioF1miuqdvn3EV5wjes3IJA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      prop-types: registry.npmjs.org/prop-types/15.8.1
-      resize-observer-polyfill: registry.npmjs.org/resize-observer-polyfill/1.5.1
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-      react-dom: registry.npmjs.org/react-dom/16.14.0_react@17.0.2
-    dev: false
-
-  /@myntra/uikit-component-modal/1.13.96:
-    resolution: {integrity: sha512-G8CapFKwjNhHqi9q0uNFllNA+TcO0QLAHOTjIbWqkdgpTA31aO4dwtxgNg2CvSsLuAAOWu2mjj3xApqVrUmYzw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-portal': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-nav-bar/1.13.96:
-    resolution: {integrity: sha512-9z6xIbdrgMX9Zmw0Ll6WXMCjV+XCrioEFZSj9tMfLYzOs8w5MSRpaMKwmudQsB683WS3FBHlXe4bRkTC5SqahQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-avatar': 1.13.96
-      '@myntra/uikit-component-click-away': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-context': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-notification/1.13.96:
-    resolution: {integrity: sha512-DZgNv8TcE5ERRdAi/krNAggjbUu7Q9vA06bkKRLaubgNCW7KgA5RaPJx+lajcPBs5n8RC/33K8x62yBLabmG/A==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-section': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-page/1.13.96:
-    resolution: {integrity: sha512-iVPxqYK4ggYJyVXcxPDkIuYpnXgGLON7aZJTqqh87JEq8FemlyJEcfD9HN4H5VK5ZoZfsVQXZsnrtk/O6DX/yg==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-pagination/1.13.96:
-    resolution: {integrity: sha512-vBn1OMJTTnu8zbfkUnf+5qDSu5T8DuZ/po5sw82gk116lFtmY/s9VMzVGh22OaUR5604y6XYT9054OCvaPxpcA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-portal/1.13.96:
-    resolution: {integrity: sha512-G1OwJ3tDwRXGFtzjXy96+dJfyFjIPO1OOyKBprzE0PaznOVdFbJguOCF8j/0r6MfdDtlkjBIokd74d+6A3W8Sw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      prop-types: registry.npmjs.org/prop-types/15.8.1
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-      react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
-    dev: false
-
-  /@myntra/uikit-component-progress/1.13.96:
-    resolution: {integrity: sha512-K+Q1BsgRvhAL3iSLj2rvwpqGxgOqwtsOnOMtojML4RITHAdaWDATIDzBCWBh62VwouB0TpXmnV8vMRBJEtpwSQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-schema-form/1.13.96:
-    resolution: {integrity: sha512-9/HWdfnseCA9+U1HouQTUp0aIPyCV18XFGW9dWir1nUa+7ofezxqgHsc1Rji4ASI/1EOkZ9rEkHIpOG0BqdrwA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-field': 1.13.96
-      '@myntra/uikit-component-form': 1.13.96
-      '@myntra/uikit-component-grid': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-section/1.13.96:
-    resolution: {integrity: sha512-Jy1XPluorcIOanTr3d6hBvM3clZHvuC233pDzADIlDZSMdIJsRGsb+0l/QL0We60luc6jSML+p8fmSBCi5Bqvg==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-stepper/1.13.96:
-    resolution: {integrity: sha512-InIV1OFVPnyBTCZjZ2gbYg8bCmuo12Gv4F2CRpfmWdU4TtgpJFfA/h/W6D7+4U7SS5ZwYiVCYk1oxPDNwSKkMA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      prop-types: registry.npmjs.org/prop-types/15.8.1
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-table/1.13.96:
-    resolution: {integrity: sha512-7GNMeeOieLwbLkq4CyMxWis/H0qkmWoRlxFEw2HWTKwcRVHWv24dNuvGPiOgZ689ELIsMeihHWxTPAVgGQNZOQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-field': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-component-list': 1.13.96
-      '@myntra/uikit-component-measure': 1.13.96
-      '@myntra/uikit-component-virtual-grid': 1.13.96
-      '@myntra/uikit-component-virtual-list': 1.13.96
-      '@myntra/uikit-context': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-tabs/1.13.96:
-    resolution: {integrity: sha512-1ssGbUhJie8tw3mMWxbezgugpUhK62rueuJi4STq/mGog8Iu8Cb2cBNGoL6jzdLrKTGNUMn86LyQlJubOUd2Bw==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-text/1.13.96:
-    resolution: {integrity: sha512-RrAQGFvPOknngZ5epuozFhNhcfPY4uUr0CC4QU0Ao8bz09NebTaEUppnb8VEG7PBHS8LMQ4JvrSevX9OruCGSg==}
-    dependencies:
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-tooltip/1.13.96:
-    resolution: {integrity: sha512-Hfplcaw2M1fIvJQvCKlkwzy92kf2lfLEaBdJuMklrsDZvxjWoj7YZt6vTG0bo3TUFpOlm5KBxp/DVVmcmPCBWQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-top-bar/1.13.96:
-    resolution: {integrity: sha512-tBUQPOmFFR0d5NJH/AQwKV+AhrMBSLI+xOFj7qo/AU394U9xMLo/V7b+E18YD2MXzlzmvGfFtFv2vjkrLDmKZQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-bread-crumb': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-virtual-grid/1.13.96:
-    resolution: {integrity: sha512-uQWS3+6+PfpNuGjc0eQjkJI9LGYsQkEyC5xmxGQ6jDaU+Yw6VL8ZGNNspWktIoo9PjJgF2SIY2CjtNfKDOAYew==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-virtual-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-    dev: false
-
-  /@myntra/uikit-component-virtual-list/1.13.96:
-    resolution: {integrity: sha512-x4/0Y1MBfhrdVEtAnJgwMPO/GpiPzg6O6hZz9dIW6Lu/fHxPse3oCXHqQvR9crrUWdnKFYqoVf3GE4r0UNGYqQ==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      '@myntra/uikit-component-measure': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      uikit-icons: /@myntra/uikit-icons/1.0.31
-    optionalDependencies:
-      react: registry.npmjs.org/react/17.0.2
-      react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
-    dev: false
-
-  /@myntra/uikit-context/1.13.96:
-    resolution: {integrity: sha512-yQ4IykzgX033sK/EFnDxX6xZ7R35VSzH5R7jviLk4WwsnlixJwxDP79ruOmBsTO0waHJiJllK8E4uMKSjs/eiA==}
-    dependencies:
-      '@myntra/uikit-can-i-use': 1.13.96
-      react: registry.npmjs.org/react/16.14.0
-    dev: false
-
-  /@myntra/uikit-design/1.13.96:
-    resolution: {integrity: sha512-0cgQksG9TpoNNRP7WQbfWE5bveFp1NSTxdPn+xskLUVVRvsdYC4xzC+FzwliJDkKq/uhJCywx4WUz3WRzGhPzw==}
-    dev: true
-
   /@myntra/uikit-icons/1.0.31:
     resolution: {integrity: sha512-Nhi5vQiLhakdOUx6GxXMAf0iOrnDH/FtP6ocjcSNBq1PZ1uoNcJg8S0NvNsG33IXu8qa2xxIAToiGGVr4RIVpw==}
     engines: {node: '>=8.0'}
     optionalDependencies:
-      react: 17.0.2
-
-  /@myntra/uikit-utils/1.13.96:
-    resolution: {integrity: sha512-Cg7S9FdpSKoVQvqF/f7bJfm0xTLn+SqCyg70oJsMxML0ASzEbEeM2En0MLPkb6CptvnGf6JiDnPao8b8oI6xTg==}
-    optionalDependencies:
-      react: registry.npmjs.org/react/16.14.0
-    dev: false
-
-  /@myntra/uikit/1.13.96:
-    resolution: {integrity: sha512-69bwyM5ehWmUOnVpquxXAFib8kPAJE67XgsR09HhUelbYDMFeztNpUOOKkKgt4ZoRT9yJVGY8L2BMPQ4hWkOCA==}
-    requiresBuild: true
-    dependencies:
-      '@myntra/accoutrement': 1.13.96
-      '@myntra/uikit-component-accordion': 1.13.96
-      '@myntra/uikit-component-avatar': 1.13.96
-      '@myntra/uikit-component-badge': 1.13.96
-      '@myntra/uikit-component-banner': 1.13.96
-      '@myntra/uikit-component-bread-crumb': 1.13.96
-      '@myntra/uikit-component-button': 1.13.96
-      '@myntra/uikit-component-button-group': 1.13.96
-      '@myntra/uikit-component-click-away': 1.13.96
-      '@myntra/uikit-component-dropdown': 1.13.96
-      '@myntra/uikit-component-error-boundary': 1.13.96
-      '@myntra/uikit-component-fab': 1.13.96
-      '@myntra/uikit-component-field': 1.13.96
-      '@myntra/uikit-component-flex': 1.13.96
-      '@myntra/uikit-component-form': 1.13.96
-      '@myntra/uikit-component-grid': 1.13.96
-      '@myntra/uikit-component-group': 1.13.96
-      '@myntra/uikit-component-icon': 1.13.96
-      '@myntra/uikit-component-image': 1.13.96
-      '@myntra/uikit-component-input-azure-file': 1.13.65
-      '@myntra/uikit-component-input-checkbox': 1.13.96
-      '@myntra/uikit-component-input-date': 1.13.96
-      '@myntra/uikit-component-input-file': 1.13.96
-      '@myntra/uikit-component-input-masked': 1.13.96
-      '@myntra/uikit-component-input-month': 1.13.96
-      '@myntra/uikit-component-input-number': 1.13.96
-      '@myntra/uikit-component-input-radio': 1.13.96
-      '@myntra/uikit-component-input-s3-file': 1.13.96
-      '@myntra/uikit-component-input-select': 1.13.96
-      '@myntra/uikit-component-input-text': 1.13.96
-      '@myntra/uikit-component-input-text-area': 1.13.96
-      '@myntra/uikit-component-job-tracker': 1.13.96
-      '@myntra/uikit-component-layout': 1.13.96
-      '@myntra/uikit-component-list': 1.13.96
-      '@myntra/uikit-component-loader': 1.13.96
-      '@myntra/uikit-component-measure': 1.13.96
-      '@myntra/uikit-component-modal': 1.13.96
-      '@myntra/uikit-component-nav-bar': 1.13.96
-      '@myntra/uikit-component-notification': 1.13.96
-      '@myntra/uikit-component-page': 1.13.96
-      '@myntra/uikit-component-pagination': 1.13.96
-      '@myntra/uikit-component-portal': 1.13.96
-      '@myntra/uikit-component-progress': 1.13.96
-      '@myntra/uikit-component-schema-form': 1.13.96
-      '@myntra/uikit-component-section': 1.13.96
-      '@myntra/uikit-component-stepper': 1.13.96
-      '@myntra/uikit-component-table': 1.13.96
-      '@myntra/uikit-component-tabs': 1.13.96
-      '@myntra/uikit-component-text': 1.13.96
-      '@myntra/uikit-component-tooltip': 1.13.96
-      '@myntra/uikit-component-top-bar': 1.13.96
-      '@myntra/uikit-component-virtual-grid': 1.13.96
-      '@myntra/uikit-component-virtual-list': 1.13.96
-      '@myntra/uikit-utils': 1.13.96
-      normalize.css: registry.npmjs.org/normalize.css/8.0.1
-      print-message: registry.npmjs.org/print-message/3.0.1
-    dev: false
+      react: registry.npmjs.org/react/17.0.2
 
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -4120,7 +3348,7 @@ packages:
     resolution: {integrity: sha512-/D4wFhiEjUDfPu+j5FVK0g/jf7rqeEIpNfAI+kyxzLpw5CKO0drnW3W5NC38alIjsWgnyQ8pbuPF5+UD+vhVyg==}
     dependencies:
       '@types/cheerio': 0.22.30
-      '@types/react': 17.0.33
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
     dev: true
 
   /@types/eslint-scope/3.7.1:
@@ -4200,43 +3428,13 @@ packages:
   /@types/node/16.11.6:
     resolution: {integrity: sha512-ua7PgUoeQFjmWPcoo9khiPum3Pd60k4/2ZGXt18sm2Slk0W0xZTqt5Y0Ny1NyBiN1EVQ/+FaF9NcY4Qe6rwk5w==}
 
-  /@types/prop-types/15.7.4:
-    resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==}
-    dev: true
-
   /@types/q/1.5.5:
     resolution: {integrity: sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==}
-
-  /@types/react-dom/16.9.14:
-    resolution: {integrity: sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==}
-    dependencies:
-      '@types/react': 16.14.20
-    dev: true
-
-  /@types/react/16.14.20:
-    resolution: {integrity: sha512-SV7TaVc8e9E/5Xuv6TIyJ5VhQpZoVFJqX6IZgj5HZoFCtIDCArE3qXkcHlc6O/Ud4UwcMoX+tlvDA95YrKdLgA==}
-    dependencies:
-      '@types/prop-types': 15.7.4
-      '@types/scheduler': 0.16.2
-      csstype: 3.0.9
-    dev: true
-
-  /@types/react/17.0.33:
-    resolution: {integrity: sha512-pLWntxXpDPaU+RTAuSGWGSEL2FRTNyRQOjSWDke/rxRg14ncsZvx8AKWMWZqvc1UOaJIAoObdZhAWvRaHFi5rw==}
-    dependencies:
-      '@types/prop-types': 15.7.4
-      '@types/scheduler': 0.16.2
-      csstype: 3.0.9
-    dev: true
 
   /@types/resolve/0.0.8:
     resolution: {integrity: sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==}
     dependencies:
       '@types/node': 16.11.6
-    dev: true
-
-  /@types/scheduler/0.16.2:
-    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
     dev: true
 
   /@types/source-list-map/0.1.2:
@@ -6457,7 +5655,7 @@ packages:
       path-is-absolute: 1.0.1
       readdirp: 2.2.1
     optionalDependencies:
-      fsevents: 1.2.13
+      fsevents: registry.npmjs.org/fsevents/1.2.13
     dev: false
 
   /chokidar/2.1.8:
@@ -6476,7 +5674,7 @@ packages:
       readdirp: 2.2.1
       upath: 1.2.0
     optionalDependencies:
-      fsevents: 1.2.13
+      fsevents: registry.npmjs.org/fsevents/1.2.13
     dev: true
 
   /chokidar/3.5.2:
@@ -6491,7 +5689,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: registry.npmjs.org/fsevents/2.3.2
 
   /chownr/1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -7322,10 +6520,6 @@ packages:
       cssom: 0.3.8
     dev: true
 
-  /csstype/3.0.9:
-    resolution: {integrity: sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==}
-    dev: true
-
   /csv-parse/4.16.3:
     resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==}
     dev: false
@@ -7985,7 +7179,7 @@ packages:
       esutils: 2.0.3
       optionator: 0.8.3
     optionalDependencies:
-      source-map: 0.6.1
+      source-map: registry.npmjs.org/source-map/0.6.1
     dev: true
 
   /eslint-config-prettier/2.10.0_eslint@8.1.0:
@@ -9083,23 +8277,6 @@ packages:
     resolution: {integrity: sha1-invTcYa23d84E/I4WLV+yq9eQdQ=}
     dev: false
 
-  /fsevents/1.2.13:
-    resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
-    engines: {node: '>= 4.0'}
-    os: [darwin]
-    deprecated: fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.
-    requiresBuild: true
-    dependencies:
-      bindings: 1.5.0
-      nan: 2.15.0
-    optional: true
-
-  /fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    optional: true
-
   /function-bind/1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
 
@@ -9406,7 +8583,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.14.3
+      uglify-js: registry.npmjs.org/uglify-js/3.14.3
     dev: true
 
   /har-schema/2.0.0:
@@ -10622,7 +9799,7 @@ packages:
       sane: 4.1.0
       walker: 1.0.8
     optionalDependencies:
-      fsevents: 1.2.13
+      fsevents: registry.npmjs.org/fsevents/1.2.13
     dev: true
 
   /jest-jasmine2/24.9.0:
@@ -11098,7 +10275,7 @@ packages:
   /jsonfile/4.0.0:
     resolution: {integrity: sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=}
     optionalDependencies:
-      graceful-fs: 4.2.8
+      graceful-fs: registry.npmjs.org/graceful-fs/4.2.8
     dev: true
 
   /jsonparse/1.3.1:
@@ -13644,30 +12821,6 @@ packages:
       scheduler: 0.19.1
     dev: true
 
-  /react-dom/16.14.0_react@17.0.2:
-    resolution: {integrity: sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==}
-    peerDependencies:
-      react: ^16.14.0
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      prop-types: 15.7.2
-      react: 17.0.2
-      scheduler: 0.19.1
-    optional: true
-
-  /react-dom/17.0.2_react@17.0.2:
-    resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
-    peerDependencies:
-      react: 17.0.2
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react: 17.0.2
-      scheduler: 0.20.2
-    dev: false
-    optional: true
-
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -13690,14 +12843,6 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       prop-types: 15.7.2
-
-  /react/17.0.2:
-    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-    optional: true
 
   /read-cache/1.0.0:
     resolution: {integrity: sha1-5mTvMRYRZsl1HNvo28+GtftY93Q=}
@@ -15375,7 +14520,7 @@ packages:
     peerDependencies:
       stylelint: 7.x - 11.x
     dependencies:
-      stylelint: 10.1.0
+      stylelint: registry.npmjs.org/stylelint/10.1.0
     dev: false
 
   /stylelint-config-prettier/5.3.0_stylelint@10.1.0:
@@ -15385,7 +14530,7 @@ packages:
     peerDependencies:
       stylelint: ^9.1.1 || ^10.0.0 || ^11.0.0
     dependencies:
-      stylelint: 10.1.0
+      stylelint: registry.npmjs.org/stylelint/10.1.0
     dev: false
 
   /stylelint-config-recess-order/2.5.0_stylelint@10.1.0:
@@ -15393,7 +14538,7 @@ packages:
     peerDependencies:
       stylelint: '>=9'
     dependencies:
-      stylelint: 10.1.0
+      stylelint: registry.npmjs.org/stylelint/10.1.0
       stylelint-order: 4.1.0_stylelint@10.1.0
     dev: false
 
@@ -15402,7 +14547,7 @@ packages:
     peerDependencies:
       stylelint: ^8.3.0 || ^9.0.0 || ^10.0.0
     dependencies:
-      stylelint: 10.1.0
+      stylelint: registry.npmjs.org/stylelint/10.1.0
     dev: false
 
   /stylelint-config-standard/18.3.0_stylelint@10.1.0:
@@ -15410,7 +14555,7 @@ packages:
     peerDependencies:
       stylelint: ^8.3.0 || ^9.0.0 || ^10.0.0
     dependencies:
-      stylelint: 10.1.0
+      stylelint: registry.npmjs.org/stylelint/10.1.0
       stylelint-config-recommended: 2.2.0_stylelint@10.1.0
     dev: false
 
@@ -15422,7 +14567,7 @@ packages:
       lodash: 4.17.21
       postcss: 7.0.39
       postcss-sorting: 5.0.1
-      stylelint: 10.1.0
+      stylelint: registry.npmjs.org/stylelint/10.1.0
     dev: false
 
   /stylelint-scss/3.21.0_stylelint@10.1.0:
@@ -15436,66 +14581,8 @@ packages:
       postcss-resolve-nested-selector: 0.1.1
       postcss-selector-parser: 6.0.6
       postcss-value-parser: 4.1.0
-      stylelint: 10.1.0
+      stylelint: registry.npmjs.org/stylelint/10.1.0
     dev: false
-
-  /stylelint/10.1.0:
-    resolution: {integrity: sha512-OmlUXrgzEMLQYj1JPTpyZPR9G4bl0StidfHnGJEMpdiQ0JyTq0MPg1xkHk1/xVJ2rTPESyJCDWjG8Kbpoo7Kuw==}
-    engines: {node: '>=8.7.0'}
-    hasBin: true
-    dependencies:
-      autoprefixer: 9.8.8
-      balanced-match: 1.0.2
-      chalk: 2.4.2
-      cosmiconfig: 5.2.1
-      debug: 4.3.2
-      execall: 2.0.0
-      file-entry-cache: 5.0.1
-      get-stdin: 7.0.0
-      global-modules: 2.0.0
-      globby: 9.2.0
-      globjoin: 0.1.4
-      html-tags: 3.1.0
-      ignore: 5.1.8
-      import-lazy: 4.0.0
-      imurmurhash: 0.1.4
-      known-css-properties: 0.14.0
-      leven: 3.1.0
-      lodash: 4.17.21
-      log-symbols: 3.0.0
-      mathml-tag-names: 2.1.3
-      meow: 5.0.0
-      micromatch: 4.0.4
-      normalize-selector: 0.2.0
-      pify: 4.0.1
-      postcss: 7.0.39
-      postcss-html: 0.36.0_4f7b71a942b8b7a555b8adf78f88122b
-      postcss-jsx: 0.36.4_4f7b71a942b8b7a555b8adf78f88122b
-      postcss-less: 3.1.4
-      postcss-markdown: 0.36.0_4f7b71a942b8b7a555b8adf78f88122b
-      postcss-media-query-parser: 0.2.3
-      postcss-reporter: 6.0.1
-      postcss-resolve-nested-selector: 0.1.1
-      postcss-safe-parser: 4.0.2
-      postcss-sass: 0.3.5
-      postcss-scss: 2.1.1
-      postcss-selector-parser: 3.1.2
-      postcss-syntax: 0.36.2_postcss@7.0.39
-      postcss-value-parser: 3.3.1
-      resolve-from: 5.0.0
-      signal-exit: 3.0.5
-      slash: 3.0.0
-      specificity: 0.4.1
-      string-width: 4.2.3
-      strip-ansi: 5.2.0
-      style-search: 0.1.0
-      sugarss: 2.0.0
-      svg-tags: 1.0.0
-      table: 5.4.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-    optional: true
 
   /stylelint/9.10.1:
     resolution: {integrity: sha512-9UiHxZhOAHEgeQ7oLGwrwoDR8vclBKlSX7r4fH0iuu0SfPwFaLkb1c7Q2j1cqg9P7IDXeAV2TvQML/fRQzGBBQ==}
@@ -16049,13 +15136,6 @@ packages:
     resolution: {integrity: sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=}
     dev: false
 
-  /uglify-js/3.14.3:
-    resolution: {integrity: sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g==}
-    engines: {node: '>=0.8.0'}
-    hasBin: true
-    dev: true
-    optional: true
-
   /uglify-js/3.4.10:
     resolution: {integrity: sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==}
     engines: {node: '>=0.8.0'}
@@ -16467,21 +15547,14 @@ packages:
       makeerror: 1.0.12
     dev: true
 
-  /watchpack-chokidar2/2.0.1:
-    resolution: {integrity: sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==}
-    dependencies:
-      chokidar: 2.1.8
-    dev: true
-    optional: true
-
   /watchpack/1.7.5:
     resolution: {integrity: sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==}
     dependencies:
       graceful-fs: 4.2.8
       neo-async: 2.6.2
     optionalDependencies:
-      chokidar: 3.5.2
-      watchpack-chokidar2: 2.0.1
+      chokidar: registry.npmjs.org/chokidar/3.5.2
+      watchpack-chokidar2: registry.npmjs.org/watchpack-chokidar2/2.0.1
     dev: true
 
   /watchpack/2.2.0:
@@ -16988,119 +16061,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  registry.npmjs.org/@babel/code-frame/7.0.0-beta.44:
-    resolution: {integrity: sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz}
-    name: '@babel/code-frame'
-    version: 7.0.0-beta.44
-    dependencies:
-      '@babel/highlight': registry.npmjs.org/@babel/highlight/7.0.0-beta.44
-    dev: false
-
-  registry.npmjs.org/@babel/generator/7.0.0-beta.44:
-    resolution: {integrity: sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz}
-    name: '@babel/generator'
-    version: 7.0.0-beta.44
-    dependencies:
-      '@babel/types': registry.npmjs.org/@babel/types/7.0.0-beta.44
-      jsesc: registry.npmjs.org/jsesc/2.5.2
-      lodash: registry.npmjs.org/lodash/4.17.21
-      source-map: registry.npmjs.org/source-map/0.5.7
-      trim-right: registry.npmjs.org/trim-right/1.0.1
-    dev: false
-
-  registry.npmjs.org/@babel/helper-function-name/7.0.0-beta.44:
-    resolution: {integrity: sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz}
-    name: '@babel/helper-function-name'
-    version: 7.0.0-beta.44
-    dependencies:
-      '@babel/helper-get-function-arity': registry.npmjs.org/@babel/helper-get-function-arity/7.0.0-beta.44
-      '@babel/template': registry.npmjs.org/@babel/template/7.0.0-beta.44
-      '@babel/types': registry.npmjs.org/@babel/types/7.0.0-beta.44
-    dev: false
-
-  registry.npmjs.org/@babel/helper-get-function-arity/7.0.0-beta.44:
-    resolution: {integrity: sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz}
-    name: '@babel/helper-get-function-arity'
-    version: 7.0.0-beta.44
-    dependencies:
-      '@babel/types': registry.npmjs.org/@babel/types/7.0.0-beta.44
-    dev: false
-
-  registry.npmjs.org/@babel/helper-split-export-declaration/7.0.0-beta.44:
-    resolution: {integrity: sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz}
-    name: '@babel/helper-split-export-declaration'
-    version: 7.0.0-beta.44
-    dependencies:
-      '@babel/types': registry.npmjs.org/@babel/types/7.0.0-beta.44
-    dev: false
-
-  registry.npmjs.org/@babel/highlight/7.0.0-beta.44:
-    resolution: {integrity: sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz}
-    name: '@babel/highlight'
-    version: 7.0.0-beta.44
-    dependencies:
-      chalk: registry.npmjs.org/chalk/2.4.2
-      esutils: registry.npmjs.org/esutils/2.0.3
-      js-tokens: registry.npmjs.org/js-tokens/3.0.2
-    dev: false
-
-  registry.npmjs.org/@babel/runtime-corejs3/7.16.0:
-    resolution: {integrity: sha512-Oi2qwQ21X7/d9gn3WiwkDTJmq3TQtYNz89lRnoFy8VeZpWlsyXvzSwiRrRZ8cXluvSwqKxqHJ6dBd9Rv+p0ZGQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.0.tgz}
-    name: '@babel/runtime-corejs3'
-    version: 7.16.0
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      core-js-pure: registry.npmjs.org/core-js-pure/3.19.0
-      regenerator-runtime: registry.npmjs.org/regenerator-runtime/0.13.9
-    dev: false
-
-  registry.npmjs.org/@babel/runtime/7.16.0:
-    resolution: {integrity: sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz}
-    name: '@babel/runtime'
-    version: 7.16.0
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      regenerator-runtime: registry.npmjs.org/regenerator-runtime/0.13.9
-    dev: false
-
-  registry.npmjs.org/@babel/template/7.0.0-beta.44:
-    resolution: {integrity: sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz}
-    name: '@babel/template'
-    version: 7.0.0-beta.44
-    dependencies:
-      '@babel/code-frame': registry.npmjs.org/@babel/code-frame/7.0.0-beta.44
-      '@babel/types': registry.npmjs.org/@babel/types/7.0.0-beta.44
-      babylon: registry.npmjs.org/babylon/7.0.0-beta.44
-      lodash: registry.npmjs.org/lodash/4.17.21
-    dev: false
-
-  registry.npmjs.org/@babel/traverse/7.0.0-beta.44:
-    resolution: {integrity: sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz}
-    name: '@babel/traverse'
-    version: 7.0.0-beta.44
-    dependencies:
-      '@babel/code-frame': registry.npmjs.org/@babel/code-frame/7.0.0-beta.44
-      '@babel/generator': registry.npmjs.org/@babel/generator/7.0.0-beta.44
-      '@babel/helper-function-name': registry.npmjs.org/@babel/helper-function-name/7.0.0-beta.44
-      '@babel/helper-split-export-declaration': registry.npmjs.org/@babel/helper-split-export-declaration/7.0.0-beta.44
-      '@babel/types': registry.npmjs.org/@babel/types/7.0.0-beta.44
-      babylon: registry.npmjs.org/babylon/7.0.0-beta.44
-      debug: registry.npmjs.org/debug/3.2.7
-      globals: registry.npmjs.org/globals/11.12.0
-      invariant: registry.npmjs.org/invariant/2.2.4
-      lodash: registry.npmjs.org/lodash/4.17.21
-    dev: false
-
-  registry.npmjs.org/@babel/types/7.0.0-beta.44:
-    resolution: {integrity: sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz}
-    name: '@babel/types'
-    version: 7.0.0-beta.44
-    dependencies:
-      esutils: registry.npmjs.org/esutils/2.0.3
-      lodash: registry.npmjs.org/lodash/4.17.21
-      to-fast-properties: registry.npmjs.org/to-fast-properties/2.0.0
-    dev: false
-
   registry.npmjs.org/@eslint/eslintrc/1.0.3:
     resolution: {integrity: sha512-DHI1wDPoKCBPoLZA3qDR91+3te/wDSc1YhKg3jR8NxKKRJq2hwHwcWv31cSwSYvIBrmbENoYMWcenW8uproQqg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.3.tgz}
     name: '@eslint/eslintrc'
@@ -17142,38 +16102,28 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/@types/json5/0.0.29:
-    resolution: {integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz}
-    name: '@types/json5'
-    version: 0.0.29
-    dev: false
-
   registry.npmjs.org/@types/prop-types/15.7.4:
     resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz}
     name: '@types/prop-types'
     version: 15.7.4
     dev: true
 
-  registry.npmjs.org/@types/react/18.0.15:
-    resolution: {integrity: sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz}
+  registry.npmjs.org/@types/react-dom/17.0.2:
+    resolution: {integrity: sha512-Icd9KEgdnFfJs39KyRyr0jQ7EKhq8U6CcHRMGAS45fp5qgUvxL3ujUCfWFttUK2UErqZNj97t9gsVPNAqcwoCg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.2.tgz}
+    name: '@types/react-dom'
+    version: 17.0.2
+    dependencies:
+      '@types/react': registry.npmjs.org/@types/react/17.0.2
+    dev: true
+
+  registry.npmjs.org/@types/react/17.0.2:
+    resolution: {integrity: sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz}
     name: '@types/react'
-    version: 18.0.15
+    version: 17.0.2
     dependencies:
       '@types/prop-types': registry.npmjs.org/@types/prop-types/15.7.4
-      '@types/scheduler': registry.npmjs.org/@types/scheduler/0.16.2
       csstype: registry.npmjs.org/csstype/3.0.9
     dev: true
-
-  registry.npmjs.org/@types/scheduler/0.16.2:
-    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz}
-    name: '@types/scheduler'
-    version: 0.16.2
-    dev: true
-
-  registry.npmjs.org/accoutrement/2.2.0:
-    resolution: {integrity: sha512-aY6D3v2ZXIs3AsyIy9en80Dpv89jCkGeG9ILhRO2q6lpPNfgmldYgOO5UcdQlQm14n3Tf4IrNIz4Ijz0A8bYlw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/accoutrement/-/accoutrement-2.2.0.tgz}
-    name: accoutrement
-    version: 2.2.0
 
   registry.npmjs.org/acorn-jsx/5.3.2_acorn@8.5.0:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz}
@@ -17205,6 +16155,8 @@ packages:
       fast-json-stable-stringify: registry.npmjs.org/fast-json-stable-stringify/2.1.0
       json-schema-traverse: registry.npmjs.org/json-schema-traverse/0.4.1
       uri-js: registry.npmjs.org/uri-js/4.4.1
+    dev: false
+    optional: true
 
   registry.npmjs.org/ansi-colors/4.1.1:
     resolution: {integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz}
@@ -17214,13 +16166,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/ansi-regex/2.1.1:
-    resolution: {integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz}
-    name: ansi-regex
-    version: 2.1.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   registry.npmjs.org/ansi-regex/5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz}
     name: ansi-regex
@@ -17228,21 +16173,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
     optional: true
-
-  registry.npmjs.org/ansi-styles/2.2.1:
-    resolution: {integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz}
-    name: ansi-styles
-    version: 2.2.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/ansi-styles/3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz}
-    name: ansi-styles
-    version: 3.2.1
-    engines: {node: '>=4'}
-    dependencies:
-      color-convert: registry.npmjs.org/color-convert/1.9.3
 
   registry.npmjs.org/ansi-styles/4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz}
@@ -17254,27 +16184,14 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/ansicolors/0.2.1:
-    resolution: {integrity: sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz}
-    name: ansicolors
-    version: 0.2.1
-    dev: false
-
-  registry.npmjs.org/anymatch/1.3.2:
-    resolution: {integrity: sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz}
-    name: anymatch
-    version: 1.3.2
-    dependencies:
-      micromatch: registry.npmjs.org/micromatch/2.3.11
-      normalize-path: registry.npmjs.org/normalize-path/2.1.1
-    dev: true
-
   registry.npmjs.org/argparse/1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz}
     name: argparse
     version: 1.0.10
     dependencies:
       sprintf-js: registry.npmjs.org/sprintf-js/1.0.3
+    dev: false
+    optional: true
 
   registry.npmjs.org/argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz}
@@ -17283,221 +16200,11 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/aria-query/4.2.2:
-    resolution: {integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz}
-    name: aria-query
-    version: 4.2.2
-    engines: {node: '>=6.0'}
-    dependencies:
-      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.16.0
-      '@babel/runtime-corejs3': registry.npmjs.org/@babel/runtime-corejs3/7.16.0
-    dev: false
-
-  registry.npmjs.org/arr-diff/2.0.0:
-    resolution: {integrity: sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz}
-    name: arr-diff
-    version: 2.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-flatten: registry.npmjs.org/arr-flatten/1.1.0
-    dev: true
-
-  registry.npmjs.org/arr-diff/4.0.0:
-    resolution: {integrity: sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz}
-    name: arr-diff
-    version: 4.0.0
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/arr-flatten/1.1.0:
-    resolution: {integrity: sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz}
-    name: arr-flatten
-    version: 1.1.0
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/arr-union/3.1.0:
-    resolution: {integrity: sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz}
-    name: arr-union
-    version: 3.1.0
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/array-includes/3.1.4:
-    resolution: {integrity: sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz}
-    name: array-includes
-    version: 3.1.4
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-      es-abstract: registry.npmjs.org/es-abstract/1.19.1
-      get-intrinsic: registry.npmjs.org/get-intrinsic/1.1.1
-      is-string: registry.npmjs.org/is-string/1.0.7
-    dev: false
-
-  registry.npmjs.org/array-union/1.0.2:
-    resolution: {integrity: sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz}
-    name: array-union
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      array-uniq: registry.npmjs.org/array-uniq/1.0.3
-    dev: true
-
-  registry.npmjs.org/array-uniq/1.0.3:
-    resolution: {integrity: sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz}
-    name: array-uniq
-    version: 1.0.3
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/array-unique/0.2.1:
-    resolution: {integrity: sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz}
-    name: array-unique
-    version: 0.2.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/array-unique/0.3.2:
-    resolution: {integrity: sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz}
-    name: array-unique
-    version: 0.3.2
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/array.prototype.flat/1.2.5:
-    resolution: {integrity: sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz}
-    name: array.prototype.flat
-    version: 1.2.5
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-      es-abstract: registry.npmjs.org/es-abstract/1.19.1
-    dev: false
-
-  registry.npmjs.org/array.prototype.flatmap/1.2.5:
-    resolution: {integrity: sha512-08u6rVyi1Lj7oqWbS9nUxliETrtIROT4XGTA4D/LWGten6E3ocm7cy9SIrmNHOL5XVbVuckUp3X6Xyg8/zpvHA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.5.tgz}
-    name: array.prototype.flatmap
-    version: 1.2.5
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-      es-abstract: registry.npmjs.org/es-abstract/1.19.1
-    dev: false
-
-  registry.npmjs.org/assign-symbols/1.0.0:
-    resolution: {integrity: sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz}
-    name: assign-symbols
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/ast-types-flow/0.0.7:
-    resolution: {integrity: sha1-9wtzXGvKGlycItmCw+Oef+ujva0=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz}
-    name: ast-types-flow
-    version: 0.0.7
-    dev: false
-
-  registry.npmjs.org/async-each/1.0.3:
-    resolution: {integrity: sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz}
-    name: async-each
-    version: 1.0.3
-    dev: true
-
-  registry.npmjs.org/async/2.6.3:
-    resolution: {integrity: sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/async/-/async-2.6.3.tgz}
-    name: async
-    version: 2.6.3
-    dependencies:
-      lodash: registry.npmjs.org/lodash/4.17.21
-    dev: false
-
-  registry.npmjs.org/atob/2.1.2:
-    resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/atob/-/atob-2.1.2.tgz}
-    name: atob
-    version: 2.1.2
-    engines: {node: '>= 4.5.0'}
-    hasBin: true
-    dev: true
-
-  registry.npmjs.org/axe-core/4.3.5:
-    resolution: {integrity: sha512-WKTW1+xAzhMS5dJsxWkliixlO/PqC4VhmO9T4juNYcaTg9jzWiJsou6m5pxWYGfigWbwzJWeFY6z47a+4neRXA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/axe-core/-/axe-core-4.3.5.tgz}
-    name: axe-core
-    version: 4.3.5
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmjs.org/axobject-query/2.2.0:
-    resolution: {integrity: sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz}
-    name: axobject-query
-    version: 2.2.0
-    dev: false
-
-  registry.npmjs.org/babel-eslint/8.2.6:
-    resolution: {integrity: sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz}
-    name: babel-eslint
-    version: 8.2.6
-    engines: {node: '>=4'}
-    dependencies:
-      '@babel/code-frame': registry.npmjs.org/@babel/code-frame/7.0.0-beta.44
-      '@babel/traverse': registry.npmjs.org/@babel/traverse/7.0.0-beta.44
-      '@babel/types': registry.npmjs.org/@babel/types/7.0.0-beta.44
-      babylon: registry.npmjs.org/babylon/7.0.0-beta.44
-      eslint-scope: registry.npmjs.org/eslint-scope/3.7.1
-      eslint-visitor-keys: registry.npmjs.org/eslint-visitor-keys/1.3.0
-    dev: false
-
-  registry.npmjs.org/babel-plugin-syntax-jsx/6.18.0:
-    resolution: {integrity: sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz}
-    name: babel-plugin-syntax-jsx
-    version: 6.18.0
-    dev: false
-
-  registry.npmjs.org/babylon/7.0.0-beta.44:
-    resolution: {integrity: sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz}
-    name: babylon
-    version: 7.0.0-beta.44
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: false
-
   registry.npmjs.org/balanced-match/1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz}
     name: balanced-match
     version: 1.0.2
-
-  registry.npmjs.org/base/0.11.2:
-    resolution: {integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/base/-/base-0.11.2.tgz}
-    name: base
-    version: 0.11.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      cache-base: registry.npmjs.org/cache-base/1.0.1
-      class-utils: registry.npmjs.org/class-utils/0.3.6
-      component-emitter: registry.npmjs.org/component-emitter/1.3.0
-      define-property: registry.npmjs.org/define-property/1.0.0
-      isobject: registry.npmjs.org/isobject/3.0.1
-      mixin-deep: registry.npmjs.org/mixin-deep/1.3.2
-      pascalcase: registry.npmjs.org/pascalcase/0.1.1
-    dev: true
-
-  registry.npmjs.org/binary-extensions/1.13.1:
-    resolution: {integrity: sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz}
-    name: binary-extensions
-    version: 1.13.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/bindings/1.5.0:
-    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz}
-    name: bindings
-    version: 1.5.0
-    dependencies:
-      file-uri-to-path: registry.npmjs.org/file-uri-to-path/1.0.0
-    dev: true
+    dev: false
     optional: true
 
   registry.npmjs.org/brace-expansion/1.1.11:
@@ -17507,61 +16214,8 @@ packages:
     dependencies:
       balanced-match: registry.npmjs.org/balanced-match/1.0.2
       concat-map: registry.npmjs.org/concat-map/0.0.1
-
-  registry.npmjs.org/braces/1.8.5:
-    resolution: {integrity: sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/braces/-/braces-1.8.5.tgz}
-    name: braces
-    version: 1.8.5
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      expand-range: registry.npmjs.org/expand-range/1.8.2
-      preserve: registry.npmjs.org/preserve/0.2.0
-      repeat-element: registry.npmjs.org/repeat-element/1.1.4
-    dev: true
-
-  registry.npmjs.org/braces/2.3.2:
-    resolution: {integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/braces/-/braces-2.3.2.tgz}
-    name: braces
-    version: 2.3.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-flatten: registry.npmjs.org/arr-flatten/1.1.0
-      array-unique: registry.npmjs.org/array-unique/0.3.2
-      extend-shallow: registry.npmjs.org/extend-shallow/2.0.1
-      fill-range: registry.npmjs.org/fill-range/4.0.0
-      isobject: registry.npmjs.org/isobject/3.0.1
-      repeat-element: registry.npmjs.org/repeat-element/1.1.4
-      snapdragon: registry.npmjs.org/snapdragon/0.8.2
-      snapdragon-node: registry.npmjs.org/snapdragon-node/2.1.1
-      split-string: registry.npmjs.org/split-string/3.1.0
-      to-regex: registry.npmjs.org/to-regex/3.0.2
-    dev: true
-
-  registry.npmjs.org/cache-base/1.0.1:
-    resolution: {integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz}
-    name: cache-base
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      collection-visit: registry.npmjs.org/collection-visit/1.0.0
-      component-emitter: registry.npmjs.org/component-emitter/1.3.0
-      get-value: registry.npmjs.org/get-value/2.0.6
-      has-value: registry.npmjs.org/has-value/1.0.0
-      isobject: registry.npmjs.org/isobject/3.0.1
-      set-value: registry.npmjs.org/set-value/2.0.1
-      to-object-path: registry.npmjs.org/to-object-path/0.3.0
-      union-value: registry.npmjs.org/union-value/1.0.1
-      unset-value: registry.npmjs.org/unset-value/1.0.0
-    dev: true
-
-  registry.npmjs.org/call-bind/1.0.2:
-    resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz}
-    name: call-bind
-    version: 1.0.2
-    dependencies:
-      function-bind: registry.npmjs.org/function-bind/1.1.1
-      get-intrinsic: registry.npmjs.org/get-intrinsic/1.1.1
     dev: false
+    optional: true
 
   registry.npmjs.org/callsites/3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz}
@@ -17570,46 +16224,6 @@ packages:
     engines: {node: '>=6'}
     dev: false
     optional: true
-
-  registry.npmjs.org/camelcase/5.3.1:
-    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz}
-    name: camelcase
-    version: 5.3.1
-    engines: {node: '>=6'}
-    dev: true
-
-  registry.npmjs.org/cardinal/1.0.0:
-    resolution: {integrity: sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz}
-    name: cardinal
-    version: 1.0.0
-    hasBin: true
-    dependencies:
-      ansicolors: registry.npmjs.org/ansicolors/0.2.1
-      redeyed: registry.npmjs.org/redeyed/1.0.1
-    dev: false
-
-  registry.npmjs.org/chalk/1.1.3:
-    resolution: {integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz}
-    name: chalk
-    version: 1.1.3
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-styles: registry.npmjs.org/ansi-styles/2.2.1
-      escape-string-regexp: registry.npmjs.org/escape-string-regexp/1.0.5
-      has-ansi: registry.npmjs.org/has-ansi/2.0.0
-      strip-ansi: registry.npmjs.org/strip-ansi/3.0.1
-      supports-color: registry.npmjs.org/supports-color/2.0.0
-    dev: true
-
-  registry.npmjs.org/chalk/2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz}
-    name: chalk
-    version: 2.4.2
-    engines: {node: '>=4'}
-    dependencies:
-      ansi-styles: registry.npmjs.org/ansi-styles/3.2.1
-      escape-string-regexp: registry.npmjs.org/escape-string-regexp/1.0.5
-      supports-color: registry.npmjs.org/supports-color/5.5.0
 
   registry.npmjs.org/chalk/4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz}
@@ -17622,51 +16236,24 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/chokidar/1.7.0:
-    resolution: {integrity: sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz}
+  registry.npmjs.org/chokidar/3.5.2:
+    resolution: {integrity: sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz}
     name: chokidar
-    version: 1.7.0
+    version: 3.5.2
+    engines: {node: '>= 8.10.0'}
+    requiresBuild: true
     dependencies:
-      anymatch: registry.npmjs.org/anymatch/1.3.2
-      async-each: registry.npmjs.org/async-each/1.0.3
-      glob-parent: registry.npmjs.org/glob-parent/2.0.0
-      inherits: registry.npmjs.org/inherits/2.0.4
-      is-binary-path: registry.npmjs.org/is-binary-path/1.0.1
-      is-glob: registry.npmjs.org/is-glob/2.0.1
-      path-is-absolute: registry.npmjs.org/path-is-absolute/1.0.1
-      readdirp: registry.npmjs.org/readdirp/2.2.1
+      anymatch: 3.1.2
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
     optionalDependencies:
-      fsevents: registry.npmjs.org/fsevents/1.2.13
+      fsevents: registry.npmjs.org/fsevents/2.3.2
     dev: true
-
-  registry.npmjs.org/class-utils/0.3.6:
-    resolution: {integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz}
-    name: class-utils
-    version: 0.3.6
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-union: registry.npmjs.org/arr-union/3.1.0
-      define-property: registry.npmjs.org/define-property/0.2.5
-      isobject: registry.npmjs.org/isobject/3.0.1
-      static-extend: registry.npmjs.org/static-extend/0.1.2
-    dev: true
-
-  registry.npmjs.org/collection-visit/1.0.0:
-    resolution: {integrity: sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz}
-    name: collection-visit
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      map-visit: registry.npmjs.org/map-visit/1.0.0
-      object-visit: registry.npmjs.org/object-visit/1.0.1
-    dev: true
-
-  registry.npmjs.org/color-convert/1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz}
-    name: color-convert
-    version: 1.9.3
-    dependencies:
-      color-name: registry.npmjs.org/color-name/1.1.3
+    optional: true
 
   registry.npmjs.org/color-convert/2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz}
@@ -17678,11 +16265,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/color-name/1.1.3:
-    resolution: {integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz}
-    name: color-name
-    version: 1.1.3
-
   registry.npmjs.org/color-name/1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz}
     name: color-name
@@ -17690,42 +16272,12 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/component-emitter/1.3.0:
-    resolution: {integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz}
-    name: component-emitter
-    version: 1.3.0
-    dev: true
-
-  registry.npmjs.org/compute-scroll-into-view/1.0.17:
-    resolution: {integrity: sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz}
-    name: compute-scroll-into-view
-    version: 1.0.17
-    dev: false
-
   registry.npmjs.org/concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz}
     name: concat-map
     version: 0.0.1
-
-  registry.npmjs.org/copy-descriptor/0.1.1:
-    resolution: {integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz}
-    name: copy-descriptor
-    version: 0.1.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/core-js-pure/3.19.0:
-    resolution: {integrity: sha512-UEQk8AxyCYvNAs6baNoPqDADv7BX0AmBLGxVsrAifPPx/C8EAzV4Q+2ZUJqVzfI2TQQEZITnwUkWcHpgc/IubQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.19.0.tgz}
-    name: core-js-pure
-    version: 3.19.0
-    requiresBuild: true
     dev: false
-
-  registry.npmjs.org/core-util-is/1.0.3:
-    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz}
-    name: core-util-is
-    version: 1.0.3
-    dev: true
+    optional: true
 
   registry.npmjs.org/cross-spawn/7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz}
@@ -17745,46 +16297,6 @@ packages:
     version: 3.0.9
     dev: true
 
-  registry.npmjs.org/csv-parse/4.16.3:
-    resolution: {integrity: sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz}
-    name: csv-parse
-    version: 4.16.3
-    dev: false
-
-  registry.npmjs.org/damerau-levenshtein/1.0.7:
-    resolution: {integrity: sha512-VvdQIPGdWP0SqFXghj79Wf/5LArmreyMsGLa6FG6iC4t3j7j5s71TrwWmT/4akbDQIqjfACkLZmjXhA7g2oUZw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.7.tgz}
-    name: damerau-levenshtein
-    version: 1.0.7
-    dev: false
-
-  registry.npmjs.org/date-fns/2.25.0:
-    resolution: {integrity: sha512-ovYRFnTrbGPD4nqaEqescPEv1mNwvt+UTqI3Ay9SzNtey9NZnYu6E2qCcBBgJ6/2VF1zGGygpyTDITqpQQ5e+w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/date-fns/-/date-fns-2.25.0.tgz}
-    name: date-fns
-    version: 2.25.0
-    engines: {node: '>=0.11'}
-    dev: false
-
-  registry.npmjs.org/dayjs/1.10.7:
-    resolution: {integrity: sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/dayjs/-/dayjs-1.10.7.tgz}
-    name: dayjs
-    version: 1.10.7
-    dev: false
-
-  registry.npmjs.org/debug/2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/debug/-/debug-2.6.9.tgz}
-    name: debug
-    version: 2.6.9
-    dependencies:
-      ms: registry.npmjs.org/ms/2.0.0
-
-  registry.npmjs.org/debug/3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/debug/-/debug-3.2.7.tgz}
-    name: debug
-    version: 3.2.7
-    dependencies:
-      ms: registry.npmjs.org/ms/2.1.3
-    dev: false
-
   registry.npmjs.org/debug/4.3.2:
     resolution: {integrity: sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/debug/-/debug-4.3.2.tgz}
     name: debug
@@ -17800,72 +16312,12 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/decode-uri-component/0.2.0:
-    resolution: {integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz}
-    name: decode-uri-component
-    version: 0.2.0
-    engines: {node: '>=0.10'}
-    dev: true
-
   registry.npmjs.org/deep-is/0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz}
     name: deep-is
     version: 0.1.4
     dev: false
     optional: true
-
-  registry.npmjs.org/define-properties/1.1.3:
-    resolution: {integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz}
-    name: define-properties
-    version: 1.1.3
-    engines: {node: '>= 0.4'}
-    dependencies:
-      object-keys: registry.npmjs.org/object-keys/1.1.1
-    dev: false
-
-  registry.npmjs.org/define-property/0.2.5:
-    resolution: {integrity: sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz}
-    name: define-property
-    version: 0.2.5
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-descriptor: registry.npmjs.org/is-descriptor/0.1.6
-    dev: true
-
-  registry.npmjs.org/define-property/1.0.0:
-    resolution: {integrity: sha1-dp66rz9KY6rTr56NMEybvnm/sOY=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz}
-    name: define-property
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-descriptor: registry.npmjs.org/is-descriptor/1.0.2
-    dev: true
-
-  registry.npmjs.org/define-property/2.0.2:
-    resolution: {integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz}
-    name: define-property
-    version: 2.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-descriptor: registry.npmjs.org/is-descriptor/1.0.2
-      isobject: registry.npmjs.org/isobject/3.0.1
-    dev: true
-
-  registry.npmjs.org/diff/3.5.0:
-    resolution: {integrity: sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/diff/-/diff-3.5.0.tgz}
-    name: diff
-    version: 3.5.0
-    engines: {node: '>=0.3.1'}
-    dev: true
-
-  registry.npmjs.org/doctrine/2.1.0:
-    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz}
-    name: doctrine
-    version: 2.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      esutils: registry.npmjs.org/esutils/2.0.3
-    dev: false
 
   registry.npmjs.org/doctrine/3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz}
@@ -17877,12 +16329,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/emoji-regex/9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz}
-    name: emoji-regex
-    version: 9.2.2
-    dev: false
-
   registry.npmjs.org/enquirer/2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz}
     name: enquirer
@@ -17893,51 +16339,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/es-abstract/1.19.1:
-    resolution: {integrity: sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz}
-    name: es-abstract
-    version: 1.19.1
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      es-to-primitive: registry.npmjs.org/es-to-primitive/1.2.1
-      function-bind: registry.npmjs.org/function-bind/1.1.1
-      get-intrinsic: registry.npmjs.org/get-intrinsic/1.1.1
-      get-symbol-description: registry.npmjs.org/get-symbol-description/1.0.0
-      has: registry.npmjs.org/has/1.0.3
-      has-symbols: registry.npmjs.org/has-symbols/1.0.2
-      internal-slot: registry.npmjs.org/internal-slot/1.0.3
-      is-callable: registry.npmjs.org/is-callable/1.2.4
-      is-negative-zero: registry.npmjs.org/is-negative-zero/2.0.1
-      is-regex: registry.npmjs.org/is-regex/1.1.4
-      is-shared-array-buffer: registry.npmjs.org/is-shared-array-buffer/1.0.1
-      is-string: registry.npmjs.org/is-string/1.0.7
-      is-weakref: registry.npmjs.org/is-weakref/1.0.1
-      object-inspect: registry.npmjs.org/object-inspect/1.11.0
-      object-keys: registry.npmjs.org/object-keys/1.1.1
-      object.assign: registry.npmjs.org/object.assign/4.1.2
-      string.prototype.trimend: registry.npmjs.org/string.prototype.trimend/1.0.4
-      string.prototype.trimstart: registry.npmjs.org/string.prototype.trimstart/1.0.4
-      unbox-primitive: registry.npmjs.org/unbox-primitive/1.0.1
-    dev: false
-
-  registry.npmjs.org/es-to-primitive/1.2.1:
-    resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz}
-    name: es-to-primitive
-    version: 1.2.1
-    engines: {node: '>= 0.4'}
-    dependencies:
-      is-callable: registry.npmjs.org/is-callable/1.2.4
-      is-date-object: registry.npmjs.org/is-date-object/1.0.5
-      is-symbol: registry.npmjs.org/is-symbol/1.0.4
-    dev: false
-
-  registry.npmjs.org/escape-string-regexp/1.0.5:
-    resolution: {integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz}
-    name: escape-string-regexp
-    version: 1.0.5
-    engines: {node: '>=0.8.0'}
-
   registry.npmjs.org/escape-string-regexp/4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz}
     name: escape-string-regexp
@@ -17945,231 +16346,6 @@ packages:
     engines: {node: '>=10'}
     dev: false
     optional: true
-
-  registry.npmjs.org/eslint-config-prettier/2.10.0_eslint@8.1.0:
-    resolution: {integrity: sha512-Mhl90VLucfBuhmcWBgbUNtgBiK955iCDK1+aHAz7QfDQF6wuzWZ6JjihZ3ejJoGlJWIuko7xLqNm8BA5uenKhA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-2.10.0.tgz}
-    id: registry.npmjs.org/eslint-config-prettier/2.10.0
-    name: eslint-config-prettier
-    version: 2.10.0
-    hasBin: true
-    peerDependencies:
-      eslint: '>=3.14.1'
-    dependencies:
-      eslint: registry.npmjs.org/eslint/8.1.0
-      get-stdin: registry.npmjs.org/get-stdin/5.0.1
-    dev: false
-
-  registry.npmjs.org/eslint-config-standard/11.0.0_b5bc100c81ef684327d30b90513037eb:
-    resolution: {integrity: sha512-oDdENzpViEe5fwuRCWla7AXQd++/oyIp8zP+iP9jiUPG6NBj3SHgdgtl/kTn00AjeN+1HNvavTKmYbMo+xMOlw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-11.0.0.tgz}
-    id: registry.npmjs.org/eslint-config-standard/11.0.0
-    name: eslint-config-standard
-    version: 11.0.0
-    peerDependencies:
-      eslint: '>=4.18.0'
-      eslint-plugin-import: '>=2.8.0'
-      eslint-plugin-node: '>=5.2.1'
-      eslint-plugin-promise: '>=3.6.0'
-      eslint-plugin-standard: '>=3.0.1'
-    dependencies:
-      eslint: registry.npmjs.org/eslint/8.1.0
-      eslint-plugin-import: registry.npmjs.org/eslint-plugin-import/2.25.2_eslint@8.1.0
-      eslint-plugin-node: registry.npmjs.org/eslint-plugin-node/6.0.1_eslint@8.1.0
-      eslint-plugin-promise: registry.npmjs.org/eslint-plugin-promise/3.8.0
-      eslint-plugin-standard: registry.npmjs.org/eslint-plugin-standard/3.1.0_eslint@8.1.0
-    dev: false
-
-  registry.npmjs.org/eslint-import-resolver-node/0.3.6:
-    resolution: {integrity: sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz}
-    name: eslint-import-resolver-node
-    version: 0.3.6
-    dependencies:
-      debug: registry.npmjs.org/debug/3.2.7
-      resolve: registry.npmjs.org/resolve/1.20.0
-    dev: false
-
-  registry.npmjs.org/eslint-module-utils/2.7.1:
-    resolution: {integrity: sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.7.1.tgz}
-    name: eslint-module-utils
-    version: 2.7.1
-    engines: {node: '>=4'}
-    dependencies:
-      debug: registry.npmjs.org/debug/3.2.7
-      find-up: registry.npmjs.org/find-up/2.1.0
-      pkg-dir: registry.npmjs.org/pkg-dir/2.0.0
-    dev: false
-
-  registry.npmjs.org/eslint-plugin-babel/5.3.1_eslint@8.1.0:
-    resolution: {integrity: sha512-VsQEr6NH3dj664+EyxJwO4FCYm/00JhYb3Sk3ft8o+fpKuIfQ9TaW6uVUfvwMXHcf/lsnRIoyFPsLMyiWCSL/g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.1.tgz}
-    id: registry.npmjs.org/eslint-plugin-babel/5.3.1
-    name: eslint-plugin-babel
-    version: 5.3.1
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: '>=4.0.0'
-    dependencies:
-      eslint: registry.npmjs.org/eslint/8.1.0
-      eslint-rule-composer: registry.npmjs.org/eslint-rule-composer/0.3.0
-    dev: false
-
-  registry.npmjs.org/eslint-plugin-import/2.25.2_eslint@8.1.0:
-    resolution: {integrity: sha512-qCwQr9TYfoBHOFcVGKY9C9unq05uOxxdklmBXLVvcwo68y5Hta6/GzCZEMx2zQiu0woKNEER0LE7ZgaOfBU14g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.2.tgz}
-    id: registry.npmjs.org/eslint-plugin-import/2.25.2
-    name: eslint-plugin-import
-    version: 2.25.2
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
-    dependencies:
-      array-includes: registry.npmjs.org/array-includes/3.1.4
-      array.prototype.flat: registry.npmjs.org/array.prototype.flat/1.2.5
-      debug: registry.npmjs.org/debug/2.6.9
-      doctrine: registry.npmjs.org/doctrine/2.1.0
-      eslint: registry.npmjs.org/eslint/8.1.0
-      eslint-import-resolver-node: registry.npmjs.org/eslint-import-resolver-node/0.3.6
-      eslint-module-utils: registry.npmjs.org/eslint-module-utils/2.7.1
-      has: registry.npmjs.org/has/1.0.3
-      is-core-module: registry.npmjs.org/is-core-module/2.8.0
-      is-glob: registry.npmjs.org/is-glob/4.0.3
-      minimatch: registry.npmjs.org/minimatch/3.0.4
-      object.values: registry.npmjs.org/object.values/1.1.5
-      resolve: registry.npmjs.org/resolve/1.20.0
-      tsconfig-paths: registry.npmjs.org/tsconfig-paths/3.11.0
-    dev: false
-
-  registry.npmjs.org/eslint-plugin-jest/21.27.2_eslint@8.1.0:
-    resolution: {integrity: sha512-0E4OIgBJVlAmf1KfYFtZ3gYxgUzC5Eb3Jzmrc9ikI1OY+/cM8Kh72Ti7KfpeHNeD3HJNf9SmEfmvQLIz44Hrhw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-21.27.2.tgz}
-    id: registry.npmjs.org/eslint-plugin-jest/21.27.2
-    name: eslint-plugin-jest
-    version: 21.27.2
-    engines: {node: '>= 4'}
-    peerDependencies:
-      eslint: '>=3.6'
-    dependencies:
-      eslint: registry.npmjs.org/eslint/8.1.0
-    dev: false
-
-  registry.npmjs.org/eslint-plugin-json/1.4.0:
-    resolution: {integrity: sha512-CECvgRAWtUzuepdlPWd+VA7fhyF9HT183pZnl8wQw5x699Mk/MbME/q8xtULBfooi3LUbj6fToieNmsvUcDxWA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.4.0.tgz}
-    name: eslint-plugin-json
-    version: 1.4.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      vscode-json-languageservice: registry.npmjs.org/vscode-json-languageservice/3.11.0
-    dev: false
-
-  registry.npmjs.org/eslint-plugin-jsx-a11y/6.4.1_eslint@8.1.0:
-    resolution: {integrity: sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz}
-    id: registry.npmjs.org/eslint-plugin-jsx-a11y/6.4.1
-    name: eslint-plugin-jsx-a11y
-    version: 6.4.1
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7
-    dependencies:
-      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.16.0
-      aria-query: registry.npmjs.org/aria-query/4.2.2
-      array-includes: registry.npmjs.org/array-includes/3.1.4
-      ast-types-flow: registry.npmjs.org/ast-types-flow/0.0.7
-      axe-core: registry.npmjs.org/axe-core/4.3.5
-      axobject-query: registry.npmjs.org/axobject-query/2.2.0
-      damerau-levenshtein: registry.npmjs.org/damerau-levenshtein/1.0.7
-      emoji-regex: registry.npmjs.org/emoji-regex/9.2.2
-      eslint: registry.npmjs.org/eslint/8.1.0
-      has: registry.npmjs.org/has/1.0.3
-      jsx-ast-utils: registry.npmjs.org/jsx-ast-utils/3.2.1
-      language-tags: registry.npmjs.org/language-tags/1.0.5
-    dev: false
-
-  registry.npmjs.org/eslint-plugin-node/6.0.1_eslint@8.1.0:
-    resolution: {integrity: sha512-Q/Cc2sW1OAISDS+Ji6lZS2KV4b7ueA/WydVWd1BECTQwVvfQy5JAi3glhINoKzoMnfnuRgNP+ZWKrGAbp3QDxw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-6.0.1.tgz}
-    id: registry.npmjs.org/eslint-plugin-node/6.0.1
-    name: eslint-plugin-node
-    version: 6.0.1
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: '>=3.1.0'
-    dependencies:
-      eslint: registry.npmjs.org/eslint/8.1.0
-      ignore: registry.npmjs.org/ignore/3.3.10
-      minimatch: registry.npmjs.org/minimatch/3.0.4
-      resolve: registry.npmjs.org/resolve/1.20.0
-      semver: registry.npmjs.org/semver/5.7.1
-    dev: false
-
-  registry.npmjs.org/eslint-plugin-prettier/2.7.0_prettier@1.19.1:
-    resolution: {integrity: sha512-CStQYJgALoQBw3FsBzH0VOVDRnJ/ZimUlpLm226U8qgqYJfPOY/CPK6wyRInMxh73HSKg5wyRwdS4BVYYHwokA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.7.0.tgz}
-    id: registry.npmjs.org/eslint-plugin-prettier/2.7.0
-    name: eslint-plugin-prettier
-    version: 2.7.0
-    engines: {node: '>=4.0.0'}
-    peerDependencies:
-      prettier: '>= 0.11.0'
-    dependencies:
-      fast-diff: registry.npmjs.org/fast-diff/1.2.0
-      jest-docblock: registry.npmjs.org/jest-docblock/21.2.0
-      prettier: registry.npmjs.org/prettier/1.19.1
-    dev: false
-
-  registry.npmjs.org/eslint-plugin-promise/3.8.0:
-    resolution: {integrity: sha512-JiFL9UFR15NKpHyGii1ZcvmtIqa3UTwiDAGb8atSffe43qJ3+1czVGN6UtkklpcJ2DVnqvTMzEKRaJdBkAL2aQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.8.0.tgz}
-    name: eslint-plugin-promise
-    version: 3.8.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmjs.org/eslint-plugin-react/7.26.1_eslint@8.1.0:
-    resolution: {integrity: sha512-Lug0+NOFXeOE+ORZ5pbsh6mSKjBKXDXItUD2sQoT+5Yl0eoT82DqnXeTMfUare4QVCn9QwXbfzO/dBLjLXwVjQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.26.1.tgz}
-    id: registry.npmjs.org/eslint-plugin-react/7.26.1
-    name: eslint-plugin-react
-    version: 7.26.1
-    engines: {node: '>=4'}
-    peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7
-    dependencies:
-      array-includes: registry.npmjs.org/array-includes/3.1.4
-      array.prototype.flatmap: registry.npmjs.org/array.prototype.flatmap/1.2.5
-      doctrine: registry.npmjs.org/doctrine/2.1.0
-      eslint: registry.npmjs.org/eslint/8.1.0
-      estraverse: registry.npmjs.org/estraverse/5.3.0
-      jsx-ast-utils: registry.npmjs.org/jsx-ast-utils/3.2.1
-      minimatch: registry.npmjs.org/minimatch/3.0.4
-      object.entries: registry.npmjs.org/object.entries/1.1.5
-      object.fromentries: registry.npmjs.org/object.fromentries/2.0.5
-      object.hasown: registry.npmjs.org/object.hasown/1.1.0
-      object.values: registry.npmjs.org/object.values/1.1.5
-      prop-types: registry.npmjs.org/prop-types/15.8.1
-      resolve: registry.npmjs.org/resolve/2.0.0-next.3
-      semver: registry.npmjs.org/semver/6.3.0
-      string.prototype.matchall: registry.npmjs.org/string.prototype.matchall/4.0.6
-    dev: false
-
-  registry.npmjs.org/eslint-plugin-standard/3.1.0_eslint@8.1.0:
-    resolution: {integrity: sha512-fVcdyuKRr0EZ4fjWl3c+gp1BANFJD1+RaWa2UPYfMZ6jCtp5RG00kSaXnK/dE5sYzt4kaWJ9qdxqUfc0d9kX0w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.1.0.tgz}
-    id: registry.npmjs.org/eslint-plugin-standard/3.1.0
-    name: eslint-plugin-standard
-    version: 3.1.0
-    peerDependencies:
-      eslint: '>=3.19.0'
-    dependencies:
-      eslint: registry.npmjs.org/eslint/8.1.0
-    dev: false
-
-  registry.npmjs.org/eslint-rule-composer/0.3.0:
-    resolution: {integrity: sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz}
-    name: eslint-rule-composer
-    version: 0.3.0
-    engines: {node: '>=4.0.0'}
-    dev: false
-
-  registry.npmjs.org/eslint-scope/3.7.1:
-    resolution: {integrity: sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz}
-    name: eslint-scope
-    version: 3.7.1
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      esrecurse: registry.npmjs.org/esrecurse/4.3.0
-      estraverse: registry.npmjs.org/estraverse/4.3.0
-    dev: false
 
   registry.npmjs.org/eslint-scope/6.0.0:
     resolution: {integrity: sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz}
@@ -18196,13 +16372,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/eslint-visitor-keys/1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz}
-    name: eslint-visitor-keys
-    version: 1.3.0
-    engines: {node: '>=4'}
-    dev: false
-
   registry.npmjs.org/eslint-visitor-keys/2.1.0:
     resolution: {integrity: sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz}
     name: eslint-visitor-keys
@@ -18225,6 +16394,7 @@ packages:
     version: 8.1.0
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
+    requiresBuild: true
     dependencies:
       '@eslint/eslintrc': registry.npmjs.org/@eslint/eslintrc/1.0.3
       '@humanwhocodes/config-array': registry.npmjs.org/@humanwhocodes/config-array/0.6.0
@@ -18281,20 +16451,14 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/esprima/3.0.0:
-    resolution: {integrity: sha1-U88kes2ncxPlUcOqLnM0LT+099k=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/esprima/-/esprima-3.0.0.tgz}
-    name: esprima
-    version: 3.0.0
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    dev: false
-
   registry.npmjs.org/esprima/4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz}
     name: esprima
     version: 4.0.1
     engines: {node: '>=4'}
     hasBin: true
+    dev: false
+    optional: true
 
   registry.npmjs.org/esquery/1.4.0:
     resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz}
@@ -18314,13 +16478,7 @@ packages:
     dependencies:
       estraverse: registry.npmjs.org/estraverse/5.3.0
     dev: false
-
-  registry.npmjs.org/estraverse/4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz}
-    name: estraverse
-    version: 4.3.0
-    engines: {node: '>=4.0'}
-    dev: false
+    optional: true
 
   registry.npmjs.org/estraverse/5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz}
@@ -18328,6 +16486,7 @@ packages:
     version: 5.3.0
     engines: {node: '>=4.0'}
     dev: false
+    optional: true
 
   registry.npmjs.org/esutils/2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz}
@@ -18335,99 +16494,21 @@ packages:
     version: 2.0.3
     engines: {node: '>=0.10.0'}
     dev: false
-
-  registry.npmjs.org/expand-brackets/0.1.5:
-    resolution: {integrity: sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz}
-    name: expand-brackets
-    version: 0.1.5
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-posix-bracket: registry.npmjs.org/is-posix-bracket/0.1.1
-    dev: true
-
-  registry.npmjs.org/expand-brackets/2.1.4:
-    resolution: {integrity: sha1-t3c14xXOMPa27/D4OwQVGiJEliI=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz}
-    name: expand-brackets
-    version: 2.1.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      debug: registry.npmjs.org/debug/2.6.9
-      define-property: registry.npmjs.org/define-property/0.2.5
-      extend-shallow: registry.npmjs.org/extend-shallow/2.0.1
-      posix-character-classes: registry.npmjs.org/posix-character-classes/0.1.1
-      regex-not: registry.npmjs.org/regex-not/1.0.2
-      snapdragon: registry.npmjs.org/snapdragon/0.8.2
-      to-regex: registry.npmjs.org/to-regex/3.0.2
-    dev: true
-
-  registry.npmjs.org/expand-range/1.8.2:
-    resolution: {integrity: sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz}
-    name: expand-range
-    version: 1.8.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      fill-range: registry.npmjs.org/fill-range/2.2.4
-    dev: true
-
-  registry.npmjs.org/extend-shallow/2.0.1:
-    resolution: {integrity: sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz}
-    name: extend-shallow
-    version: 2.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extendable: registry.npmjs.org/is-extendable/0.1.1
-    dev: true
-
-  registry.npmjs.org/extend-shallow/3.0.2:
-    resolution: {integrity: sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz}
-    name: extend-shallow
-    version: 3.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      assign-symbols: registry.npmjs.org/assign-symbols/1.0.0
-      is-extendable: registry.npmjs.org/is-extendable/1.0.1
-    dev: true
-
-  registry.npmjs.org/extglob/0.3.2:
-    resolution: {integrity: sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz}
-    name: extglob
-    version: 0.3.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extglob: registry.npmjs.org/is-extglob/1.0.0
-    dev: true
-
-  registry.npmjs.org/extglob/2.0.4:
-    resolution: {integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz}
-    name: extglob
-    version: 2.0.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      array-unique: registry.npmjs.org/array-unique/0.3.2
-      define-property: registry.npmjs.org/define-property/1.0.0
-      expand-brackets: registry.npmjs.org/expand-brackets/2.1.4
-      extend-shallow: registry.npmjs.org/extend-shallow/2.0.1
-      fragment-cache: registry.npmjs.org/fragment-cache/0.2.1
-      regex-not: registry.npmjs.org/regex-not/1.0.2
-      snapdragon: registry.npmjs.org/snapdragon/0.8.2
-      to-regex: registry.npmjs.org/to-regex/3.0.2
-    dev: true
+    optional: true
 
   registry.npmjs.org/fast-deep-equal/3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz}
     name: fast-deep-equal
     version: 3.1.3
-
-  registry.npmjs.org/fast-diff/1.2.0:
-    resolution: {integrity: sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz}
-    name: fast-diff
-    version: 1.2.0
     dev: false
+    optional: true
 
   registry.npmjs.org/fast-json-stable-stringify/2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz}
     name: fast-json-stable-stringify
     version: 2.1.0
+    dev: false
+    optional: true
 
   registry.npmjs.org/fast-levenshtein/2.0.6:
     resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz}
@@ -18445,54 +16526,6 @@ packages:
       flat-cache: registry.npmjs.org/flat-cache/3.0.4
     dev: false
     optional: true
-
-  registry.npmjs.org/file-uri-to-path/1.0.0:
-    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz}
-    name: file-uri-to-path
-    version: 1.0.0
-    dev: true
-    optional: true
-
-  registry.npmjs.org/filename-regex/2.0.1:
-    resolution: {integrity: sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz}
-    name: filename-regex
-    version: 2.0.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/fill-range/2.2.4:
-    resolution: {integrity: sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz}
-    name: fill-range
-    version: 2.2.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-number: registry.npmjs.org/is-number/2.1.0
-      isobject: registry.npmjs.org/isobject/2.1.0
-      randomatic: registry.npmjs.org/randomatic/3.1.1
-      repeat-element: registry.npmjs.org/repeat-element/1.1.4
-      repeat-string: registry.npmjs.org/repeat-string/1.6.1
-    dev: true
-
-  registry.npmjs.org/fill-range/4.0.0:
-    resolution: {integrity: sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz}
-    name: fill-range
-    version: 4.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      extend-shallow: registry.npmjs.org/extend-shallow/2.0.1
-      is-number: registry.npmjs.org/is-number/3.0.0
-      repeat-string: registry.npmjs.org/repeat-string/1.6.1
-      to-regex-range: registry.npmjs.org/to-regex-range/2.1.1
-    dev: true
-
-  registry.npmjs.org/find-up/2.1.0:
-    resolution: {integrity: sha1-RdG35QbHF93UgndaK3eSCjwMV6c=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz}
-    name: find-up
-    version: 2.1.0
-    engines: {node: '>=4'}
-    dependencies:
-      locate-path: registry.npmjs.org/locate-path/2.0.0
-    dev: false
 
   registry.npmjs.org/flat-cache/3.0.4:
     resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz}
@@ -18512,35 +16545,12 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/for-in/1.0.2:
-    resolution: {integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz}
-    name: for-in
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/for-own/0.1.5:
-    resolution: {integrity: sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz}
-    name: for-own
-    version: 0.1.5
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      for-in: registry.npmjs.org/for-in/1.0.2
-    dev: true
-
-  registry.npmjs.org/fragment-cache/0.2.1:
-    resolution: {integrity: sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz}
-    name: fragment-cache
-    version: 0.2.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      map-cache: registry.npmjs.org/map-cache/0.2.2
-    dev: true
-
   registry.npmjs.org/fs.realpath/1.0.0:
     resolution: {integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz}
     name: fs.realpath
     version: 1.0.0
+    dev: false
+    optional: true
 
   registry.npmjs.org/fsevents/1.2.13:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz}
@@ -18550,16 +16560,18 @@ packages:
     os: [darwin]
     requiresBuild: true
     dependencies:
-      bindings: registry.npmjs.org/bindings/1.5.0
-      nan: registry.npmjs.org/nan/2.15.0
-    dev: true
+      bindings: 1.5.0
+      nan: 2.15.0
     optional: true
 
-  registry.npmjs.org/function-bind/1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz}
-    name: function-bind
-    version: 1.1.1
-    dev: false
+  registry.npmjs.org/fsevents/2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz}
+    name: fsevents
+    version: 2.3.2
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    optional: true
 
   registry.npmjs.org/functional-red-black-tree/1.0.1:
     resolution: {integrity: sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz}
@@ -18567,58 +16579,6 @@ packages:
     version: 1.0.1
     dev: false
     optional: true
-
-  registry.npmjs.org/get-intrinsic/1.1.1:
-    resolution: {integrity: sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz}
-    name: get-intrinsic
-    version: 1.1.1
-    dependencies:
-      function-bind: registry.npmjs.org/function-bind/1.1.1
-      has: registry.npmjs.org/has/1.0.3
-      has-symbols: registry.npmjs.org/has-symbols/1.0.2
-    dev: false
-
-  registry.npmjs.org/get-stdin/5.0.1:
-    resolution: {integrity: sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.1.tgz}
-    name: get-stdin
-    version: 5.0.1
-    engines: {node: '>=0.12.0'}
-    dev: false
-
-  registry.npmjs.org/get-symbol-description/1.0.0:
-    resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz}
-    name: get-symbol-description
-    version: 1.0.0
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      get-intrinsic: registry.npmjs.org/get-intrinsic/1.1.1
-    dev: false
-
-  registry.npmjs.org/get-value/2.0.6:
-    resolution: {integrity: sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz}
-    name: get-value
-    version: 2.0.6
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/glob-base/0.3.0:
-    resolution: {integrity: sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz}
-    name: glob-base
-    version: 0.3.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      glob-parent: registry.npmjs.org/glob-parent/2.0.0
-      is-glob: registry.npmjs.org/is-glob/2.0.1
-    dev: true
-
-  registry.npmjs.org/glob-parent/2.0.0:
-    resolution: {integrity: sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz}
-    name: glob-parent
-    version: 2.0.0
-    dependencies:
-      is-glob: registry.npmjs.org/is-glob/2.0.1
-    dev: true
 
   registry.npmjs.org/glob-parent/6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz}
@@ -18641,13 +16601,8 @@ packages:
       minimatch: registry.npmjs.org/minimatch/3.0.4
       once: registry.npmjs.org/once/1.4.0
       path-is-absolute: registry.npmjs.org/path-is-absolute/1.0.1
-
-  registry.npmjs.org/globals/11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/globals/-/globals-11.12.0.tgz}
-    name: globals
-    version: 11.12.0
-    engines: {node: '>=4'}
     dev: false
+    optional: true
 
   registry.npmjs.org/globals/13.12.0:
     resolution: {integrity: sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/globals/-/globals-13.12.0.tgz}
@@ -18659,45 +16614,13 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/globby/6.1.0:
-    resolution: {integrity: sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/globby/-/globby-6.1.0.tgz}
-    name: globby
-    version: 6.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      array-union: registry.npmjs.org/array-union/1.0.2
-      glob: registry.npmjs.org/glob/7.2.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-      pify: registry.npmjs.org/pify/2.3.0
-      pinkie-promise: registry.npmjs.org/pinkie-promise/2.0.1
-    dev: true
-
   registry.npmjs.org/graceful-fs/4.2.8:
     resolution: {integrity: sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz}
     name: graceful-fs
     version: 4.2.8
+    requiresBuild: true
     dev: true
-
-  registry.npmjs.org/has-ansi/2.0.0:
-    resolution: {integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz}
-    name: has-ansi
-    version: 2.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-regex: registry.npmjs.org/ansi-regex/2.1.1
-    dev: true
-
-  registry.npmjs.org/has-bigints/1.0.1:
-    resolution: {integrity: sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz}
-    name: has-bigints
-    version: 1.0.1
-    dev: false
-
-  registry.npmjs.org/has-flag/3.0.0:
-    resolution: {integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz}
-    name: has-flag
-    version: 3.0.0
-    engines: {node: '>=4'}
+    optional: true
 
   registry.npmjs.org/has-flag/4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz}
@@ -18706,82 +16629,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
     optional: true
-
-  registry.npmjs.org/has-symbols/1.0.2:
-    resolution: {integrity: sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz}
-    name: has-symbols
-    version: 1.0.2
-    engines: {node: '>= 0.4'}
-    dev: false
-
-  registry.npmjs.org/has-tostringtag/1.0.0:
-    resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz}
-    name: has-tostringtag
-    version: 1.0.0
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-symbols: registry.npmjs.org/has-symbols/1.0.2
-    dev: false
-
-  registry.npmjs.org/has-value/0.3.1:
-    resolution: {integrity: sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz}
-    name: has-value
-    version: 0.3.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      get-value: registry.npmjs.org/get-value/2.0.6
-      has-values: registry.npmjs.org/has-values/0.1.4
-      isobject: registry.npmjs.org/isobject/2.1.0
-    dev: true
-
-  registry.npmjs.org/has-value/1.0.0:
-    resolution: {integrity: sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz}
-    name: has-value
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      get-value: registry.npmjs.org/get-value/2.0.6
-      has-values: registry.npmjs.org/has-values/1.0.0
-      isobject: registry.npmjs.org/isobject/3.0.1
-    dev: true
-
-  registry.npmjs.org/has-values/0.1.4:
-    resolution: {integrity: sha1-bWHeldkd/Km5oCCJrThL/49it3E=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz}
-    name: has-values
-    version: 0.1.4
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/has-values/1.0.0:
-    resolution: {integrity: sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz}
-    name: has-values
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-number: registry.npmjs.org/is-number/3.0.0
-      kind-of: registry.npmjs.org/kind-of/4.0.0
-    dev: true
-
-  registry.npmjs.org/has/1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/has/-/has-1.0.3.tgz}
-    name: has
-    version: 1.0.3
-    engines: {node: '>= 0.4.0'}
-    dependencies:
-      function-bind: registry.npmjs.org/function-bind/1.1.1
-    dev: false
-
-  registry.npmjs.org/humanize/0.0.9:
-    resolution: {integrity: sha1-GZT/rs3+nEQe0r2sdFK3u0yeQaQ=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/humanize/-/humanize-0.0.9.tgz}
-    name: humanize
-    version: 0.0.9
-    dev: false
-
-  registry.npmjs.org/ignore/3.3.10:
-    resolution: {integrity: sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz}
-    name: ignore
-    version: 3.3.10
-    dev: false
 
   registry.npmjs.org/ignore/4.0.6:
     resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz}
@@ -18817,190 +16664,15 @@ packages:
     dependencies:
       once: registry.npmjs.org/once/1.4.0
       wrappy: registry.npmjs.org/wrappy/1.0.2
+    dev: false
+    optional: true
 
   registry.npmjs.org/inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz}
     name: inherits
     version: 2.0.4
-
-  registry.npmjs.org/internal-slot/1.0.3:
-    resolution: {integrity: sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz}
-    name: internal-slot
-    version: 1.0.3
-    engines: {node: '>= 0.4'}
-    dependencies:
-      get-intrinsic: registry.npmjs.org/get-intrinsic/1.1.1
-      has: registry.npmjs.org/has/1.0.3
-      side-channel: registry.npmjs.org/side-channel/1.0.4
     dev: false
-
-  registry.npmjs.org/intersection-observer-polyfill/0.1.0:
-    resolution: {integrity: sha1-+e+OWm8+DoFz0MD9tWPkep3aIzw=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/intersection-observer-polyfill/-/intersection-observer-polyfill-0.1.0.tgz}
-    name: intersection-observer-polyfill
-    version: 0.1.0
-    dev: false
-
-  registry.npmjs.org/invariant/2.2.4:
-    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz}
-    name: invariant
-    version: 2.2.4
-    dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-    dev: false
-
-  registry.npmjs.org/is-accessor-descriptor/0.1.6:
-    resolution: {integrity: sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz}
-    name: is-accessor-descriptor
-    version: 0.1.6
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmjs.org/kind-of/3.2.2
-    dev: true
-
-  registry.npmjs.org/is-accessor-descriptor/1.0.0:
-    resolution: {integrity: sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz}
-    name: is-accessor-descriptor
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmjs.org/kind-of/6.0.3
-    dev: true
-
-  registry.npmjs.org/is-bigint/1.0.4:
-    resolution: {integrity: sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz}
-    name: is-bigint
-    version: 1.0.4
-    dependencies:
-      has-bigints: registry.npmjs.org/has-bigints/1.0.1
-    dev: false
-
-  registry.npmjs.org/is-binary-path/1.0.1:
-    resolution: {integrity: sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz}
-    name: is-binary-path
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      binary-extensions: registry.npmjs.org/binary-extensions/1.13.1
-    dev: true
-
-  registry.npmjs.org/is-boolean-object/1.1.2:
-    resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz}
-    name: is-boolean-object
-    version: 1.1.2
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      has-tostringtag: registry.npmjs.org/has-tostringtag/1.0.0
-    dev: false
-
-  registry.npmjs.org/is-buffer/1.1.6:
-    resolution: {integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz}
-    name: is-buffer
-    version: 1.1.6
-    dev: true
-
-  registry.npmjs.org/is-callable/1.2.4:
-    resolution: {integrity: sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz}
-    name: is-callable
-    version: 1.2.4
-    engines: {node: '>= 0.4'}
-    dev: false
-
-  registry.npmjs.org/is-core-module/2.8.0:
-    resolution: {integrity: sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz}
-    name: is-core-module
-    version: 2.8.0
-    dependencies:
-      has: registry.npmjs.org/has/1.0.3
-    dev: false
-
-  registry.npmjs.org/is-data-descriptor/0.1.4:
-    resolution: {integrity: sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz}
-    name: is-data-descriptor
-    version: 0.1.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmjs.org/kind-of/3.2.2
-    dev: true
-
-  registry.npmjs.org/is-data-descriptor/1.0.0:
-    resolution: {integrity: sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz}
-    name: is-data-descriptor
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmjs.org/kind-of/6.0.3
-    dev: true
-
-  registry.npmjs.org/is-date-object/1.0.5:
-    resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz}
-    name: is-date-object
-    version: 1.0.5
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: registry.npmjs.org/has-tostringtag/1.0.0
-    dev: false
-
-  registry.npmjs.org/is-descriptor/0.1.6:
-    resolution: {integrity: sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz}
-    name: is-descriptor
-    version: 0.1.6
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-accessor-descriptor: registry.npmjs.org/is-accessor-descriptor/0.1.6
-      is-data-descriptor: registry.npmjs.org/is-data-descriptor/0.1.4
-      kind-of: registry.npmjs.org/kind-of/5.1.0
-    dev: true
-
-  registry.npmjs.org/is-descriptor/1.0.2:
-    resolution: {integrity: sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz}
-    name: is-descriptor
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-accessor-descriptor: registry.npmjs.org/is-accessor-descriptor/1.0.0
-      is-data-descriptor: registry.npmjs.org/is-data-descriptor/1.0.0
-      kind-of: registry.npmjs.org/kind-of/6.0.3
-    dev: true
-
-  registry.npmjs.org/is-dotfile/1.0.3:
-    resolution: {integrity: sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz}
-    name: is-dotfile
-    version: 1.0.3
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/is-equal-shallow/0.1.3:
-    resolution: {integrity: sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz}
-    name: is-equal-shallow
-    version: 0.1.3
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-primitive: registry.npmjs.org/is-primitive/2.0.0
-    dev: true
-
-  registry.npmjs.org/is-extendable/0.1.1:
-    resolution: {integrity: sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz}
-    name: is-extendable
-    version: 0.1.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/is-extendable/1.0.1:
-    resolution: {integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz}
-    name: is-extendable
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-plain-object: registry.npmjs.org/is-plain-object/2.0.4
-    dev: true
-
-  registry.npmjs.org/is-extglob/1.0.0:
-    resolution: {integrity: sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz}
-    name: is-extglob
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dev: true
+    optional: true
 
   registry.npmjs.org/is-extglob/2.1.1:
     resolution: {integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz}
@@ -19008,15 +16680,7 @@ packages:
     version: 2.1.1
     engines: {node: '>=0.10.0'}
     dev: false
-
-  registry.npmjs.org/is-glob/2.0.1:
-    resolution: {integrity: sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz}
-    name: is-glob
-    version: 2.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-extglob: registry.npmjs.org/is-extglob/1.0.0
-    dev: true
+    optional: true
 
   registry.npmjs.org/is-glob/4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz}
@@ -19026,125 +16690,7 @@ packages:
     dependencies:
       is-extglob: registry.npmjs.org/is-extglob/2.1.1
     dev: false
-
-  registry.npmjs.org/is-negative-zero/2.0.1:
-    resolution: {integrity: sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz}
-    name: is-negative-zero
-    version: 2.0.1
-    engines: {node: '>= 0.4'}
-    dev: false
-
-  registry.npmjs.org/is-number-object/1.0.6:
-    resolution: {integrity: sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz}
-    name: is-number-object
-    version: 1.0.6
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: registry.npmjs.org/has-tostringtag/1.0.0
-    dev: false
-
-  registry.npmjs.org/is-number/2.1.0:
-    resolution: {integrity: sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz}
-    name: is-number
-    version: 2.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmjs.org/kind-of/3.2.2
-    dev: true
-
-  registry.npmjs.org/is-number/3.0.0:
-    resolution: {integrity: sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz}
-    name: is-number
-    version: 3.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmjs.org/kind-of/3.2.2
-    dev: true
-
-  registry.npmjs.org/is-number/4.0.0:
-    resolution: {integrity: sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz}
-    name: is-number
-    version: 4.0.0
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/is-plain-object/2.0.4:
-    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz}
-    name: is-plain-object
-    version: 2.0.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      isobject: registry.npmjs.org/isobject/3.0.1
-    dev: true
-
-  registry.npmjs.org/is-posix-bracket/0.1.1:
-    resolution: {integrity: sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz}
-    name: is-posix-bracket
-    version: 0.1.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/is-primitive/2.0.0:
-    resolution: {integrity: sha1-IHurkWOEmcB7Kt8kCkGochADRXU=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz}
-    name: is-primitive
-    version: 2.0.0
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/is-regex/1.1.4:
-    resolution: {integrity: sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz}
-    name: is-regex
-    version: 1.1.4
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      has-tostringtag: registry.npmjs.org/has-tostringtag/1.0.0
-    dev: false
-
-  registry.npmjs.org/is-shared-array-buffer/1.0.1:
-    resolution: {integrity: sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz}
-    name: is-shared-array-buffer
-    version: 1.0.1
-    dev: false
-
-  registry.npmjs.org/is-string/1.0.7:
-    resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz}
-    name: is-string
-    version: 1.0.7
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-tostringtag: registry.npmjs.org/has-tostringtag/1.0.0
-    dev: false
-
-  registry.npmjs.org/is-symbol/1.0.4:
-    resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz}
-    name: is-symbol
-    version: 1.0.4
-    engines: {node: '>= 0.4'}
-    dependencies:
-      has-symbols: registry.npmjs.org/has-symbols/1.0.2
-    dev: false
-
-  registry.npmjs.org/is-weakref/1.0.1:
-    resolution: {integrity: sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz}
-    name: is-weakref
-    version: 1.0.1
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-    dev: false
-
-  registry.npmjs.org/is-windows/1.0.2:
-    resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz}
-    name: is-windows
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/isarray/1.0.0:
-    resolution: {integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz}
-    name: isarray
-    version: 1.0.0
-    dev: true
+    optional: true
 
   registry.npmjs.org/isexe/2.0.0:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz}
@@ -19153,39 +16699,12 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/isobject/2.1.0:
-    resolution: {integrity: sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz}
-    name: isobject
-    version: 2.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      isarray: registry.npmjs.org/isarray/1.0.0
-    dev: true
-
-  registry.npmjs.org/isobject/3.0.1:
-    resolution: {integrity: sha1-TkMekrEalzFjaqH5yNHMvP2reN8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz}
-    name: isobject
-    version: 3.0.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/jest-docblock/21.2.0:
-    resolution: {integrity: sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz}
-    name: jest-docblock
-    version: 21.2.0
-    dev: false
-
-  registry.npmjs.org/js-tokens/3.0.2:
-    resolution: {integrity: sha1-mGbfOVECEw449/mWvOtlRDIJwls=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz}
-    name: js-tokens
-    version: 3.0.2
-    dev: false
-
   registry.npmjs.org/js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz}
     name: js-tokens
     version: 4.0.0
     dev: false
+    optional: true
 
   registry.npmjs.org/js-yaml/3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz}
@@ -19195,6 +16714,8 @@ packages:
     dependencies:
       argparse: registry.npmjs.org/argparse/1.0.10
       esprima: registry.npmjs.org/esprima/4.0.1
+    dev: false
+    optional: true
 
   registry.npmjs.org/js-yaml/4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz}
@@ -19206,18 +16727,12 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/jsesc/2.5.2:
-    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz}
-    name: jsesc
-    version: 2.5.2
-    engines: {node: '>=4'}
-    hasBin: true
-    dev: false
-
   registry.npmjs.org/json-schema-traverse/0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz}
     name: json-schema-traverse
     version: 0.4.1
+    dev: false
+    optional: true
 
   registry.npmjs.org/json-stable-stringify-without-jsonify/1.0.1:
     resolution: {integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz}
@@ -19225,84 +16740,6 @@ packages:
     version: 1.0.1
     dev: false
     optional: true
-
-  registry.npmjs.org/json5/1.0.1:
-    resolution: {integrity: sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/json5/-/json5-1.0.1.tgz}
-    name: json5
-    version: 1.0.1
-    hasBin: true
-    dependencies:
-      minimist: registry.npmjs.org/minimist/1.2.5
-    dev: false
-
-  registry.npmjs.org/jsonc-parser/3.0.0:
-    resolution: {integrity: sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz}
-    name: jsonc-parser
-    version: 3.0.0
-    dev: false
-
-  registry.npmjs.org/jsx-ast-utils/3.2.1:
-    resolution: {integrity: sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz}
-    name: jsx-ast-utils
-    version: 3.2.1
-    engines: {node: '>=4.0'}
-    dependencies:
-      array-includes: registry.npmjs.org/array-includes/3.1.4
-      object.assign: registry.npmjs.org/object.assign/4.1.2
-    dev: false
-
-  registry.npmjs.org/kind-of/3.2.2:
-    resolution: {integrity: sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz}
-    name: kind-of
-    version: 3.2.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-buffer: registry.npmjs.org/is-buffer/1.1.6
-    dev: true
-
-  registry.npmjs.org/kind-of/4.0.0:
-    resolution: {integrity: sha1-IIE989cSkosgc3hpGkUGb65y3Vc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz}
-    name: kind-of
-    version: 4.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-buffer: registry.npmjs.org/is-buffer/1.1.6
-    dev: true
-
-  registry.npmjs.org/kind-of/5.1.0:
-    resolution: {integrity: sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz}
-    name: kind-of
-    version: 5.1.0
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/kind-of/6.0.3:
-    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz}
-    name: kind-of
-    version: 6.0.3
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/kleur/3.0.3:
-    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz}
-    name: kleur
-    version: 3.0.3
-    engines: {node: '>=6'}
-    dev: false
-
-  registry.npmjs.org/language-subtag-registry/0.3.21:
-    resolution: {integrity: sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz}
-    name: language-subtag-registry
-    version: 0.3.21
-    dev: false
-
-  registry.npmjs.org/language-tags/1.0.5:
-    resolution: {integrity: sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz}
-    name: language-tags
-    version: 1.0.5
-    dependencies:
-      language-subtag-registry: registry.npmjs.org/language-subtag-registry/0.3.21
-    dev: false
 
   registry.npmjs.org/levn/0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/levn/-/levn-0.4.1.tgz}
@@ -19315,34 +16752,12 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/locate-path/2.0.0:
-    resolution: {integrity: sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz}
-    name: locate-path
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      p-locate: registry.npmjs.org/p-locate/2.0.0
-      path-exists: registry.npmjs.org/path-exists/3.0.0
-    dev: false
-
-  registry.npmjs.org/lodash.isplainobject/4.0.6:
-    resolution: {integrity: sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz}
-    name: lodash.isplainobject
-    version: 4.0.6
-    dev: true
-
   registry.npmjs.org/lodash.merge/4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz}
     name: lodash.merge
     version: 4.6.2
     dev: false
     optional: true
-
-  registry.npmjs.org/lodash/4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz}
-    name: lodash
-    version: 4.17.21
-    dev: false
 
   registry.npmjs.org/loose-envify/1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz}
@@ -19352,6 +16767,7 @@ packages:
     dependencies:
       js-tokens: registry.npmjs.org/js-tokens/4.0.0
     dev: false
+    optional: true
 
   registry.npmjs.org/lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz}
@@ -19363,108 +16779,14 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/luxon/1.28.0:
-    resolution: {integrity: sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz}
-    name: luxon
-    version: 1.28.0
-    dev: false
-
-  registry.npmjs.org/map-cache/0.2.2:
-    resolution: {integrity: sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz}
-    name: map-cache
-    version: 0.2.2
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/map-visit/1.0.0:
-    resolution: {integrity: sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz}
-    name: map-visit
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      object-visit: registry.npmjs.org/object-visit/1.0.1
-    dev: true
-
-  registry.npmjs.org/math-random/1.0.4:
-    resolution: {integrity: sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz}
-    name: math-random
-    version: 1.0.4
-    dev: true
-
-  registry.npmjs.org/micromatch/2.3.11:
-    resolution: {integrity: sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz}
-    name: micromatch
-    version: 2.3.11
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-diff: registry.npmjs.org/arr-diff/2.0.0
-      array-unique: registry.npmjs.org/array-unique/0.2.1
-      braces: registry.npmjs.org/braces/1.8.5
-      expand-brackets: registry.npmjs.org/expand-brackets/0.1.5
-      extglob: registry.npmjs.org/extglob/0.3.2
-      filename-regex: registry.npmjs.org/filename-regex/2.0.1
-      is-extglob: registry.npmjs.org/is-extglob/1.0.0
-      is-glob: registry.npmjs.org/is-glob/2.0.1
-      kind-of: registry.npmjs.org/kind-of/3.2.2
-      normalize-path: registry.npmjs.org/normalize-path/2.1.1
-      object.omit: registry.npmjs.org/object.omit/2.0.1
-      parse-glob: registry.npmjs.org/parse-glob/3.0.4
-      regex-cache: registry.npmjs.org/regex-cache/0.4.4
-    dev: true
-
-  registry.npmjs.org/micromatch/3.1.10:
-    resolution: {integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz}
-    name: micromatch
-    version: 3.1.10
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-diff: registry.npmjs.org/arr-diff/4.0.0
-      array-unique: registry.npmjs.org/array-unique/0.3.2
-      braces: registry.npmjs.org/braces/2.3.2
-      define-property: registry.npmjs.org/define-property/2.0.2
-      extend-shallow: registry.npmjs.org/extend-shallow/3.0.2
-      extglob: registry.npmjs.org/extglob/2.0.4
-      fragment-cache: registry.npmjs.org/fragment-cache/0.2.1
-      kind-of: registry.npmjs.org/kind-of/6.0.3
-      nanomatch: registry.npmjs.org/nanomatch/1.2.13
-      object.pick: registry.npmjs.org/object.pick/1.3.0
-      regex-not: registry.npmjs.org/regex-not/1.0.2
-      snapdragon: registry.npmjs.org/snapdragon/0.8.2
-      to-regex: registry.npmjs.org/to-regex/3.0.2
-    dev: true
-
   registry.npmjs.org/minimatch/3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz}
     name: minimatch
     version: 3.0.4
     dependencies:
       brace-expansion: registry.npmjs.org/brace-expansion/1.1.11
-
-  registry.npmjs.org/minimist/0.0.10:
-    resolution: {integrity: sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz}
-    name: minimist
-    version: 0.0.10
     dev: false
-
-  registry.npmjs.org/minimist/1.2.5:
-    resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz}
-    name: minimist
-    version: 1.2.5
-
-  registry.npmjs.org/mixin-deep/1.3.2:
-    resolution: {integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz}
-    name: mixin-deep
-    version: 1.3.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      for-in: registry.npmjs.org/for-in/1.0.2
-      is-extendable: registry.npmjs.org/is-extendable/1.0.1
-    dev: true
-
-  registry.npmjs.org/ms/2.0.0:
-    resolution: {integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ms/-/ms-2.0.0.tgz}
-    name: ms
-    version: 2.0.0
+    optional: true
 
   registry.npmjs.org/ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ms/-/ms-2.1.2.tgz}
@@ -19473,44 +16795,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/ms/2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ms/-/ms-2.1.3.tgz}
-    name: ms
-    version: 2.1.3
-    dev: false
-
-  registry.npmjs.org/name-initials/0.1.3:
-    resolution: {integrity: sha1-ua+djVUQaLHBR8UEWEd/R8Ehd3Y=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/name-initials/-/name-initials-0.1.3.tgz}
-    name: name-initials
-    version: 0.1.3
-    dev: false
-
-  registry.npmjs.org/nan/2.15.0:
-    resolution: {integrity: sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/nan/-/nan-2.15.0.tgz}
-    name: nan
-    version: 2.15.0
-    dev: true
-    optional: true
-
-  registry.npmjs.org/nanomatch/1.2.13:
-    resolution: {integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz}
-    name: nanomatch
-    version: 1.2.13
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-diff: registry.npmjs.org/arr-diff/4.0.0
-      array-unique: registry.npmjs.org/array-unique/0.3.2
-      define-property: registry.npmjs.org/define-property/2.0.2
-      extend-shallow: registry.npmjs.org/extend-shallow/3.0.2
-      fragment-cache: registry.npmjs.org/fragment-cache/0.2.1
-      is-windows: registry.npmjs.org/is-windows/1.0.2
-      kind-of: registry.npmjs.org/kind-of/6.0.3
-      object.pick: registry.npmjs.org/object.pick/1.3.0
-      regex-not: registry.npmjs.org/regex-not/1.0.2
-      snapdragon: registry.npmjs.org/snapdragon/0.8.2
-      to-regex: registry.npmjs.org/to-regex/3.0.2
-    dev: true
-
   registry.npmjs.org/natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz}
     name: natural-compare
@@ -19518,131 +16802,13 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/normalize-path/2.1.1:
-    resolution: {integrity: sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz}
-    name: normalize-path
-    version: 2.1.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      remove-trailing-separator: registry.npmjs.org/remove-trailing-separator/1.1.0
-    dev: true
-
-  registry.npmjs.org/normalize.css/8.0.1:
-    resolution: {integrity: sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz}
-    name: normalize.css
-    version: 8.0.1
-
   registry.npmjs.org/object-assign/4.1.1:
     resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz}
     name: object-assign
     version: 4.1.1
     engines: {node: '>=0.10.0'}
-
-  registry.npmjs.org/object-copy/0.1.0:
-    resolution: {integrity: sha1-fn2Fi3gb18mRpBupde04EnVOmYw=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz}
-    name: object-copy
-    version: 0.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      copy-descriptor: registry.npmjs.org/copy-descriptor/0.1.1
-      define-property: registry.npmjs.org/define-property/0.2.5
-      kind-of: registry.npmjs.org/kind-of/3.2.2
-    dev: true
-
-  registry.npmjs.org/object-inspect/1.11.0:
-    resolution: {integrity: sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz}
-    name: object-inspect
-    version: 1.11.0
     dev: false
-
-  registry.npmjs.org/object-keys/1.1.1:
-    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz}
-    name: object-keys
-    version: 1.1.1
-    engines: {node: '>= 0.4'}
-    dev: false
-
-  registry.npmjs.org/object-visit/1.0.1:
-    resolution: {integrity: sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz}
-    name: object-visit
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      isobject: registry.npmjs.org/isobject/3.0.1
-    dev: true
-
-  registry.npmjs.org/object.assign/4.1.2:
-    resolution: {integrity: sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz}
-    name: object.assign
-    version: 4.1.2
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-      has-symbols: registry.npmjs.org/has-symbols/1.0.2
-      object-keys: registry.npmjs.org/object-keys/1.1.1
-    dev: false
-
-  registry.npmjs.org/object.entries/1.1.5:
-    resolution: {integrity: sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz}
-    name: object.entries
-    version: 1.1.5
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-      es-abstract: registry.npmjs.org/es-abstract/1.19.1
-    dev: false
-
-  registry.npmjs.org/object.fromentries/2.0.5:
-    resolution: {integrity: sha512-CAyG5mWQRRiBU57Re4FKoTBjXfDoNwdFVH2Y1tS9PqCsfUTymAohOkEMSG3aRNKmv4lV3O7p1et7c187q6bynw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.5.tgz}
-    name: object.fromentries
-    version: 2.0.5
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-      es-abstract: registry.npmjs.org/es-abstract/1.19.1
-    dev: false
-
-  registry.npmjs.org/object.hasown/1.1.0:
-    resolution: {integrity: sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz}
-    name: object.hasown
-    version: 1.1.0
-    dependencies:
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-      es-abstract: registry.npmjs.org/es-abstract/1.19.1
-    dev: false
-
-  registry.npmjs.org/object.omit/2.0.1:
-    resolution: {integrity: sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz}
-    name: object.omit
-    version: 2.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      for-own: registry.npmjs.org/for-own/0.1.5
-      is-extendable: registry.npmjs.org/is-extendable/0.1.1
-    dev: true
-
-  registry.npmjs.org/object.pick/1.3.0:
-    resolution: {integrity: sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz}
-    name: object.pick
-    version: 1.3.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      isobject: registry.npmjs.org/isobject/3.0.1
-    dev: true
-
-  registry.npmjs.org/object.values/1.1.5:
-    resolution: {integrity: sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz}
-    name: object.values
-    version: 1.1.5
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-      es-abstract: registry.npmjs.org/es-abstract/1.19.1
-    dev: false
+    optional: true
 
   registry.npmjs.org/once/1.4.0:
     resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/once/-/once-1.4.0.tgz}
@@ -19650,15 +16816,8 @@ packages:
     version: 1.4.0
     dependencies:
       wrappy: registry.npmjs.org/wrappy/1.0.2
-
-  registry.npmjs.org/optimist/0.6.1:
-    resolution: {integrity: sha1-2j6nRob6IaGaERwybpDrFaAZZoY=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz}
-    name: optimist
-    version: 0.6.1
-    dependencies:
-      minimist: registry.npmjs.org/minimist/0.0.10
-      wordwrap: registry.npmjs.org/wordwrap/0.0.3
     dev: false
+    optional: true
 
   registry.npmjs.org/optionator/0.9.1:
     resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz}
@@ -19675,31 +16834,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/p-limit/1.3.0:
-    resolution: {integrity: sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz}
-    name: p-limit
-    version: 1.3.0
-    engines: {node: '>=4'}
-    dependencies:
-      p-try: registry.npmjs.org/p-try/1.0.0
-    dev: false
-
-  registry.npmjs.org/p-locate/2.0.0:
-    resolution: {integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz}
-    name: p-locate
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      p-limit: registry.npmjs.org/p-limit/1.3.0
-    dev: false
-
-  registry.npmjs.org/p-try/1.0.0:
-    resolution: {integrity: sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz}
-    name: p-try
-    version: 1.0.0
-    engines: {node: '>=4'}
-    dev: false
-
   registry.npmjs.org/parent-module/1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz}
     name: parent-module
@@ -19710,37 +16844,13 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/parse-glob/3.0.4:
-    resolution: {integrity: sha1-ssN2z7EfNVE7rdFz7wu246OIORw=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz}
-    name: parse-glob
-    version: 3.0.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      glob-base: registry.npmjs.org/glob-base/0.3.0
-      is-dotfile: registry.npmjs.org/is-dotfile/1.0.3
-      is-extglob: registry.npmjs.org/is-extglob/1.0.0
-      is-glob: registry.npmjs.org/is-glob/2.0.1
-    dev: true
-
-  registry.npmjs.org/pascalcase/0.1.1:
-    resolution: {integrity: sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz}
-    name: pascalcase
-    version: 0.1.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/path-exists/3.0.0:
-    resolution: {integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz}
-    name: path-exists
-    version: 3.0.0
-    engines: {node: '>=4'}
-    dev: false
-
   registry.npmjs.org/path-is-absolute/1.0.1:
     resolution: {integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz}
     name: path-is-absolute
     version: 1.0.1
     engines: {node: '>=0.10.0'}
+    dev: false
+    optional: true
 
   registry.npmjs.org/path-key/3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz}
@@ -19750,70 +16860,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/path-parse/1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz}
-    name: path-parse
-    version: 1.0.7
-    dev: false
-
-  registry.npmjs.org/pify/2.3.0:
-    resolution: {integrity: sha1-7RQaasBDqEnqWISY59yosVMw6Qw=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/pify/-/pify-2.3.0.tgz}
-    name: pify
-    version: 2.3.0
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/pinkie-promise/2.0.1:
-    resolution: {integrity: sha1-ITXW36ejWMBprJsXh3YogihFD/o=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz}
-    name: pinkie-promise
-    version: 2.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      pinkie: registry.npmjs.org/pinkie/2.0.4
-    dev: true
-
-  registry.npmjs.org/pinkie/2.0.4:
-    resolution: {integrity: sha1-clVrgM+g1IqXToDnckjoDtT3+HA=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz}
-    name: pinkie
-    version: 2.0.4
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/pkg-dir/2.0.0:
-    resolution: {integrity: sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz}
-    name: pkg-dir
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dependencies:
-      find-up: registry.npmjs.org/find-up/2.1.0
-    dev: false
-
-  registry.npmjs.org/posix-character-classes/0.1.1:
-    resolution: {integrity: sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz}
-    name: posix-character-classes
-    version: 0.1.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/postcss-scss/1.0.6:
-    resolution: {integrity: sha512-4EFYGHcEw+H3E06PT/pQQri06u/1VIIPjeJQaM8skB80vZuXMhp4cSNV5azmdNkontnOID/XYWEvEEELLFB1ww==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.6.tgz}
-    name: postcss-scss
-    version: 1.0.6
-    dependencies:
-      postcss: registry.npmjs.org/postcss/6.0.23
-    dev: true
-
-  registry.npmjs.org/postcss/6.0.23:
-    resolution: {integrity: sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz}
-    name: postcss
-    version: 6.0.23
-    engines: {node: '>=4.0.0'}
-    dependencies:
-      chalk: registry.npmjs.org/chalk/2.4.2
-      source-map: registry.npmjs.org/source-map/0.6.1
-      supports-color: registry.npmjs.org/supports-color/5.5.0
-    dev: true
-
   registry.npmjs.org/prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz}
     name: prelude-ls
@@ -19821,35 +16867,6 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: false
     optional: true
-
-  registry.npmjs.org/preserve/0.2.0:
-    resolution: {integrity: sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz}
-    name: preserve
-    version: 0.2.0
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/prettier/1.19.1:
-    resolution: {integrity: sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz}
-    name: prettier
-    version: 1.19.1
-    engines: {node: '>=4'}
-    hasBin: true
-
-  registry.npmjs.org/print-message/3.0.1:
-    resolution: {integrity: sha512-wsvsI08pLCPL+lHURVmlZ2KjXN/rLKNyeKN/r3FkXAX6ZByE8Fv8ZmvkQFqpdPdyfCPty3PzznrDda+E8DvN8Q==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/print-message/-/print-message-3.0.1.tgz}
-    name: print-message
-    version: 3.0.1
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      kleur: registry.npmjs.org/kleur/3.0.3
-    dev: false
-
-  registry.npmjs.org/process-nextick-args/2.0.1:
-    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz}
-    name: process-nextick-args
-    version: 2.0.1
-    dev: true
 
   registry.npmjs.org/progress/2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/progress/-/progress-2.0.3.tgz}
@@ -19868,37 +16885,30 @@ packages:
       object-assign: registry.npmjs.org/object-assign/4.1.1
       react-is: registry.npmjs.org/react-is/16.13.1
     dev: false
+    optional: true
 
   registry.npmjs.org/punycode/2.1.1:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz}
     name: punycode
     version: 2.1.1
     engines: {node: '>=6'}
-
-  registry.npmjs.org/randomatic/3.1.1:
-    resolution: {integrity: sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz}
-    name: randomatic
-    version: 3.1.1
-    engines: {node: '>= 0.10.0'}
-    dependencies:
-      is-number: registry.npmjs.org/is-number/4.0.0
-      kind-of: registry.npmjs.org/kind-of/6.0.3
-      math-random: registry.npmjs.org/math-random/1.0.4
-    dev: true
+    dev: false
+    optional: true
 
   registry.npmjs.org/react-dom/16.14.0_react@17.0.2:
     resolution: {integrity: sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz}
     id: registry.npmjs.org/react-dom/16.14.0
     name: react-dom
     version: 16.14.0
+    requiresBuild: true
     peerDependencies:
       react: ^16.14.0
     dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-      prop-types: registry.npmjs.org/prop-types/15.8.1
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      prop-types: 15.7.2
       react: registry.npmjs.org/react/17.0.2
-      scheduler: registry.npmjs.org/scheduler/0.19.1
+      scheduler: 0.19.1
     dev: false
     optional: true
 
@@ -19907,13 +16917,14 @@ packages:
     id: registry.npmjs.org/react-dom/17.0.2
     name: react-dom
     version: 17.0.2
+    requiresBuild: true
     peerDependencies:
       react: 17.0.2
     dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-      react: 17.0.2
-      scheduler: registry.npmjs.org/scheduler/0.20.2
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react: registry.npmjs.org/react/17.0.2
+      scheduler: 0.20.2
     dev: false
     optional: true
 
@@ -19922,96 +16933,31 @@ packages:
     name: react-is
     version: 16.13.1
     dev: false
+    optional: true
 
   registry.npmjs.org/react/16.14.0:
     resolution: {integrity: sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/react/-/react-16.14.0.tgz}
     name: react
     version: 16.14.0
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
       loose-envify: registry.npmjs.org/loose-envify/1.4.0
       object-assign: registry.npmjs.org/object-assign/4.1.1
       prop-types: registry.npmjs.org/prop-types/15.8.1
     dev: false
+    optional: true
 
   registry.npmjs.org/react/17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/react/-/react-17.0.2.tgz}
     name: react
     version: 17.0.2
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-    dev: false
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
     optional: true
-
-  registry.npmjs.org/readable-stream/2.3.7:
-    resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz}
-    name: readable-stream
-    version: 2.3.7
-    dependencies:
-      core-util-is: registry.npmjs.org/core-util-is/1.0.3
-      inherits: registry.npmjs.org/inherits/2.0.4
-      isarray: registry.npmjs.org/isarray/1.0.0
-      process-nextick-args: registry.npmjs.org/process-nextick-args/2.0.1
-      safe-buffer: registry.npmjs.org/safe-buffer/5.1.2
-      string_decoder: registry.npmjs.org/string_decoder/1.1.1
-      util-deprecate: registry.npmjs.org/util-deprecate/1.0.2
-    dev: true
-
-  registry.npmjs.org/readdirp/2.2.1:
-    resolution: {integrity: sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz}
-    name: readdirp
-    version: 2.2.1
-    engines: {node: '>=0.10'}
-    dependencies:
-      graceful-fs: registry.npmjs.org/graceful-fs/4.2.8
-      micromatch: registry.npmjs.org/micromatch/3.1.10
-      readable-stream: registry.npmjs.org/readable-stream/2.3.7
-    dev: true
-
-  registry.npmjs.org/redeyed/1.0.1:
-    resolution: {integrity: sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz}
-    name: redeyed
-    version: 1.0.1
-    dependencies:
-      esprima: registry.npmjs.org/esprima/3.0.0
-    dev: false
-
-  registry.npmjs.org/regenerator-runtime/0.13.9:
-    resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz}
-    name: regenerator-runtime
-    version: 0.13.9
-    dev: false
-
-  registry.npmjs.org/regex-cache/0.4.4:
-    resolution: {integrity: sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz}
-    name: regex-cache
-    version: 0.4.4
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-equal-shallow: registry.npmjs.org/is-equal-shallow/0.1.3
-    dev: true
-
-  registry.npmjs.org/regex-not/1.0.2:
-    resolution: {integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz}
-    name: regex-not
-    version: 1.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      extend-shallow: registry.npmjs.org/extend-shallow/3.0.2
-      safe-regex: registry.npmjs.org/safe-regex/1.1.0
-    dev: true
-
-  registry.npmjs.org/regexp.prototype.flags/1.3.1:
-    resolution: {integrity: sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz}
-    name: regexp.prototype.flags
-    version: 1.3.1
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-    dev: false
 
   registry.npmjs.org/regexpp/3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz}
@@ -20021,32 +16967,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/remove-trailing-separator/1.1.0:
-    resolution: {integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz}
-    name: remove-trailing-separator
-    version: 1.1.0
-    dev: true
-
-  registry.npmjs.org/repeat-element/1.1.4:
-    resolution: {integrity: sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz}
-    name: repeat-element
-    version: 1.1.4
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/repeat-string/1.6.1:
-    resolution: {integrity: sha1-jcrkcOHIirwtYA//Sndihtp15jc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz}
-    name: repeat-string
-    version: 1.6.1
-    engines: {node: '>=0.10'}
-    dev: true
-
-  registry.npmjs.org/resize-observer-polyfill/1.5.1:
-    resolution: {integrity: sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz}
-    name: resize-observer-polyfill
-    version: 1.5.1
-    dev: false
-
   registry.npmjs.org/resolve-from/4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz}
     name: resolve-from
@@ -20054,37 +16974,6 @@ packages:
     engines: {node: '>=4'}
     dev: false
     optional: true
-
-  registry.npmjs.org/resolve-url/0.2.1:
-    resolution: {integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz}
-    name: resolve-url
-    version: 0.2.1
-    dev: true
-
-  registry.npmjs.org/resolve/1.20.0:
-    resolution: {integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz}
-    name: resolve
-    version: 1.20.0
-    dependencies:
-      is-core-module: registry.npmjs.org/is-core-module/2.8.0
-      path-parse: registry.npmjs.org/path-parse/1.0.7
-    dev: false
-
-  registry.npmjs.org/resolve/2.0.0-next.3:
-    resolution: {integrity: sha512-W8LucSynKUIDu9ylraa7ueVZ7hc0uAgJBxVsQSKOXOyle8a93qXhcz+XAXZ8bIq2d6i4Ehddn6Evt+0/UwKk6Q==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz}
-    name: resolve
-    version: 2.0.0-next.3
-    dependencies:
-      is-core-module: registry.npmjs.org/is-core-module/2.8.0
-      path-parse: registry.npmjs.org/path-parse/1.0.7
-    dev: false
-
-  registry.npmjs.org/ret/0.1.15:
-    resolution: {integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/ret/-/ret-0.1.15.tgz}
-    name: ret
-    version: 0.1.15
-    engines: {node: '>=0.12'}
-    dev: true
 
   registry.npmjs.org/rimraf/3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz}
@@ -20096,62 +16985,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/safe-buffer/5.1.2:
-    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz}
-    name: safe-buffer
-    version: 5.1.2
-    dev: true
-
-  registry.npmjs.org/safe-regex/1.1.0:
-    resolution: {integrity: sha1-QKNmnzsHfR6UPURinhV91IAjvy4=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz}
-    name: safe-regex
-    version: 1.1.0
-    dependencies:
-      ret: registry.npmjs.org/ret/0.1.15
-    dev: true
-
-  registry.npmjs.org/scheduler/0.19.1:
-    resolution: {integrity: sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz}
-    name: scheduler
-    version: 0.19.1
-    dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-    dev: false
-    optional: true
-
-  registry.npmjs.org/scheduler/0.20.2:
-    resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz}
-    name: scheduler
-    version: 0.20.2
-    dependencies:
-      loose-envify: registry.npmjs.org/loose-envify/1.4.0
-      object-assign: registry.npmjs.org/object-assign/4.1.1
-    dev: false
-    optional: true
-
-  registry.npmjs.org/scroll-into-view-if-needed/2.2.28:
-    resolution: {integrity: sha512-8LuxJSuFVc92+0AdNv4QOxRL4Abeo1DgLnGNkn1XlaujPH/3cCFz3QI60r2VNu4obJJROzgnIUw5TKQkZvZI1w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.28.tgz}
-    name: scroll-into-view-if-needed
-    version: 2.2.28
-    dependencies:
-      compute-scroll-into-view: registry.npmjs.org/compute-scroll-into-view/1.0.17
-    dev: false
-
-  registry.npmjs.org/semver/5.7.1:
-    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/semver/-/semver-5.7.1.tgz}
-    name: semver
-    version: 5.7.1
-    hasBin: true
-    dev: false
-
-  registry.npmjs.org/semver/6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/semver/-/semver-6.3.0.tgz}
-    name: semver
-    version: 6.3.0
-    hasBin: true
-    dev: false
-
   registry.npmjs.org/semver/7.3.5:
     resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/semver/-/semver-7.3.5.tgz}
     name: semver
@@ -20162,18 +16995,6 @@ packages:
       lru-cache: registry.npmjs.org/lru-cache/6.0.0
     dev: false
     optional: true
-
-  registry.npmjs.org/set-value/2.0.1:
-    resolution: {integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz}
-    name: set-value
-    version: 2.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      extend-shallow: registry.npmjs.org/extend-shallow/2.0.1
-      is-extendable: registry.npmjs.org/is-extendable/0.1.1
-      is-plain-object: registry.npmjs.org/is-plain-object/2.0.4
-      split-string: registry.npmjs.org/split-string/3.1.0
-    dev: true
 
   registry.npmjs.org/shebang-command/2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz}
@@ -20193,175 +17014,21 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/side-channel/1.0.4:
-    resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz}
-    name: side-channel
-    version: 1.0.4
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      get-intrinsic: registry.npmjs.org/get-intrinsic/1.1.1
-      object-inspect: registry.npmjs.org/object-inspect/1.11.0
-    dev: false
-
-  registry.npmjs.org/sifter/0.5.4:
-    resolution: {integrity: sha512-t2yxTi/MM/ESup7XH5oMu8PUcttlekt269RqxARgnvS+7D/oP6RyA1x3M/5w8dG9OgkOyQ8hNRWelQ8Rj4TAQQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/sifter/-/sifter-0.5.4.tgz}
-    name: sifter
-    version: 0.5.4
-    hasBin: true
-    dependencies:
-      async: registry.npmjs.org/async/2.6.3
-      cardinal: registry.npmjs.org/cardinal/1.0.0
-      csv-parse: registry.npmjs.org/csv-parse/4.16.3
-      humanize: registry.npmjs.org/humanize/0.0.9
-      optimist: registry.npmjs.org/optimist/0.6.1
-    dev: false
-
-  registry.npmjs.org/snapdragon-node/2.1.1:
-    resolution: {integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz}
-    name: snapdragon-node
-    version: 2.1.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      define-property: registry.npmjs.org/define-property/1.0.0
-      isobject: registry.npmjs.org/isobject/3.0.1
-      snapdragon-util: registry.npmjs.org/snapdragon-util/3.0.1
-    dev: true
-
-  registry.npmjs.org/snapdragon-util/3.0.1:
-    resolution: {integrity: sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz}
-    name: snapdragon-util
-    version: 3.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmjs.org/kind-of/3.2.2
-    dev: true
-
-  registry.npmjs.org/snapdragon/0.8.2:
-    resolution: {integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz}
-    name: snapdragon
-    version: 0.8.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      base: registry.npmjs.org/base/0.11.2
-      debug: registry.npmjs.org/debug/2.6.9
-      define-property: registry.npmjs.org/define-property/0.2.5
-      extend-shallow: registry.npmjs.org/extend-shallow/2.0.1
-      map-cache: registry.npmjs.org/map-cache/0.2.2
-      source-map: registry.npmjs.org/source-map/0.5.7
-      source-map-resolve: registry.npmjs.org/source-map-resolve/0.5.3
-      use: registry.npmjs.org/use/3.1.1
-    dev: true
-
-  registry.npmjs.org/source-map-resolve/0.5.3:
-    resolution: {integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz}
-    name: source-map-resolve
-    version: 0.5.3
-    dependencies:
-      atob: registry.npmjs.org/atob/2.1.2
-      decode-uri-component: registry.npmjs.org/decode-uri-component/0.2.0
-      resolve-url: registry.npmjs.org/resolve-url/0.2.1
-      source-map-url: registry.npmjs.org/source-map-url/0.4.1
-      urix: registry.npmjs.org/urix/0.1.0
-    dev: true
-
-  registry.npmjs.org/source-map-url/0.4.1:
-    resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz}
-    name: source-map-url
-    version: 0.4.1
-    dev: true
-
-  registry.npmjs.org/source-map/0.5.7:
-    resolution: {integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz}
-    name: source-map
-    version: 0.5.7
-    engines: {node: '>=0.10.0'}
-
   registry.npmjs.org/source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz}
     name: source-map
     version: 0.6.1
     engines: {node: '>=0.10.0'}
+    requiresBuild: true
     dev: true
-
-  registry.npmjs.org/split-string/3.1.0:
-    resolution: {integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz}
-    name: split-string
-    version: 3.1.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      extend-shallow: registry.npmjs.org/extend-shallow/3.0.2
-    dev: true
+    optional: true
 
   registry.npmjs.org/sprintf-js/1.0.3:
     resolution: {integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz}
     name: sprintf-js
     version: 1.0.3
-
-  registry.npmjs.org/static-extend/0.1.2:
-    resolution: {integrity: sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz}
-    name: static-extend
-    version: 0.1.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      define-property: registry.npmjs.org/define-property/0.2.5
-      object-copy: registry.npmjs.org/object-copy/0.1.0
-    dev: true
-
-  registry.npmjs.org/stdin/0.0.1:
-    resolution: {integrity: sha1-0wQZgarsPf28d6GzjWNy449ftx4=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz}
-    name: stdin
-    version: 0.0.1
-    dev: true
-
-  registry.npmjs.org/string.prototype.matchall/4.0.6:
-    resolution: {integrity: sha512-6WgDX8HmQqvEd7J+G6VtAahhsQIssiZ8zl7zKh1VDMFyL3hRTJP4FTNA3RbIp2TOQ9AYNDcc7e3fH0Qbup+DBg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.6.tgz}
-    name: string.prototype.matchall
-    version: 4.0.6
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-      es-abstract: registry.npmjs.org/es-abstract/1.19.1
-      get-intrinsic: registry.npmjs.org/get-intrinsic/1.1.1
-      has-symbols: registry.npmjs.org/has-symbols/1.0.2
-      internal-slot: registry.npmjs.org/internal-slot/1.0.3
-      regexp.prototype.flags: registry.npmjs.org/regexp.prototype.flags/1.3.1
-      side-channel: registry.npmjs.org/side-channel/1.0.4
     dev: false
-
-  registry.npmjs.org/string.prototype.trimend/1.0.4:
-    resolution: {integrity: sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz}
-    name: string.prototype.trimend
-    version: 1.0.4
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-    dev: false
-
-  registry.npmjs.org/string.prototype.trimstart/1.0.4:
-    resolution: {integrity: sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz}
-    name: string.prototype.trimstart
-    version: 1.0.4
-    dependencies:
-      call-bind: registry.npmjs.org/call-bind/1.0.2
-      define-properties: registry.npmjs.org/define-properties/1.1.3
-    dev: false
-
-  registry.npmjs.org/string_decoder/1.1.1:
-    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz}
-    name: string_decoder
-    version: 1.1.1
-    dependencies:
-      safe-buffer: registry.npmjs.org/safe-buffer/5.1.2
-    dev: true
-
-  registry.npmjs.org/strip-ansi/3.0.1:
-    resolution: {integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz}
-    name: strip-ansi
-    version: 3.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      ansi-regex: registry.npmjs.org/ansi-regex/2.1.1
-    dev: true
+    optional: true
 
   registry.npmjs.org/strip-ansi/6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz}
@@ -20373,13 +17040,6 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/strip-bom/3.0.0:
-    resolution: {integrity: sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz}
-    name: strip-bom
-    version: 3.0.0
-    engines: {node: '>=4'}
-    dev: false
-
   registry.npmjs.org/strip-json-comments/3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz}
     name: strip-json-comments
@@ -20388,20 +17048,66 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/supports-color/2.0.0:
-    resolution: {integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz}
-    name: supports-color
-    version: 2.0.0
-    engines: {node: '>=0.8.0'}
-    dev: true
-
-  registry.npmjs.org/supports-color/5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz}
-    name: supports-color
-    version: 5.5.0
-    engines: {node: '>=4'}
+  registry.npmjs.org/stylelint/10.1.0:
+    resolution: {integrity: sha512-OmlUXrgzEMLQYj1JPTpyZPR9G4bl0StidfHnGJEMpdiQ0JyTq0MPg1xkHk1/xVJ2rTPESyJCDWjG8Kbpoo7Kuw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/stylelint/-/stylelint-10.1.0.tgz}
+    name: stylelint
+    version: 10.1.0
+    engines: {node: '>=8.7.0'}
+    hasBin: true
+    requiresBuild: true
     dependencies:
-      has-flag: registry.npmjs.org/has-flag/3.0.0
+      autoprefixer: 9.8.8
+      balanced-match: 1.0.2
+      chalk: 2.4.2
+      cosmiconfig: 5.2.1
+      debug: 4.3.2
+      execall: 2.0.0
+      file-entry-cache: 5.0.1
+      get-stdin: 7.0.0
+      global-modules: 2.0.0
+      globby: 9.2.0
+      globjoin: 0.1.4
+      html-tags: 3.1.0
+      ignore: 5.1.8
+      import-lazy: 4.0.0
+      imurmurhash: 0.1.4
+      known-css-properties: 0.14.0
+      leven: 3.1.0
+      lodash: 4.17.21
+      log-symbols: 3.0.0
+      mathml-tag-names: 2.1.3
+      meow: 5.0.0
+      micromatch: 4.0.4
+      normalize-selector: 0.2.0
+      pify: 4.0.1
+      postcss: 7.0.39
+      postcss-html: 0.36.0_4f7b71a942b8b7a555b8adf78f88122b
+      postcss-jsx: 0.36.4_4f7b71a942b8b7a555b8adf78f88122b
+      postcss-less: 3.1.4
+      postcss-markdown: 0.36.0_4f7b71a942b8b7a555b8adf78f88122b
+      postcss-media-query-parser: 0.2.3
+      postcss-reporter: 6.0.1
+      postcss-resolve-nested-selector: 0.1.1
+      postcss-safe-parser: 4.0.2
+      postcss-sass: 0.3.5
+      postcss-scss: 2.1.1
+      postcss-selector-parser: 3.1.2
+      postcss-syntax: 0.36.2_postcss@7.0.39
+      postcss-value-parser: 3.3.1
+      resolve-from: 5.0.0
+      signal-exit: 3.0.5
+      slash: 3.0.0
+      specificity: 0.4.1
+      string-width: 4.2.3
+      strip-ansi: 5.2.0
+      style-search: 0.1.0
+      sugarss: 2.0.0
+      svg-tags: 1.0.0
+      table: 5.4.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+    optional: true
 
   registry.npmjs.org/supports-color/7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz}
@@ -20413,91 +17119,12 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/svg-parser/1.0.6:
-    resolution: {integrity: sha512-EPd4xbh+MnF0eaiJgQziJHCKEWnrNEYMIuvRoiyPi/XmSO+gb65gMdGid9/JrucsQ80Y84NTChxE5FW0WxuO3w==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/svg-parser/-/svg-parser-1.0.6.tgz}
-    name: svg-parser
-    version: 1.0.6
-    dev: true
-
   registry.npmjs.org/text-table/0.2.0:
     resolution: {integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz}
     name: text-table
     version: 0.2.0
     dev: false
     optional: true
-
-  registry.npmjs.org/tidify/0.3.0:
-    resolution: {integrity: sha1-BeuEccCmfjLwkM37bcWG3IjCIOU=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/tidify/-/tidify-0.3.0.tgz}
-    name: tidify
-    version: 0.3.0
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      chalk: registry.npmjs.org/chalk/1.1.3
-      chokidar: registry.npmjs.org/chokidar/1.7.0
-      diff: registry.npmjs.org/diff/3.5.0
-      globby: registry.npmjs.org/globby/6.1.0
-      minimist: registry.npmjs.org/minimist/1.2.5
-      postcss: registry.npmjs.org/postcss/6.0.23
-      postcss-scss: registry.npmjs.org/postcss-scss/1.0.6
-      stdin: registry.npmjs.org/stdin/0.0.1
-    dev: true
-
-  registry.npmjs.org/to-fast-properties/2.0.0:
-    resolution: {integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz}
-    name: to-fast-properties
-    version: 2.0.0
-    engines: {node: '>=4'}
-    dev: false
-
-  registry.npmjs.org/to-object-path/0.3.0:
-    resolution: {integrity: sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz}
-    name: to-object-path
-    version: 0.3.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      kind-of: registry.npmjs.org/kind-of/3.2.2
-    dev: true
-
-  registry.npmjs.org/to-regex-range/2.1.1:
-    resolution: {integrity: sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz}
-    name: to-regex-range
-    version: 2.1.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      is-number: registry.npmjs.org/is-number/3.0.0
-      repeat-string: registry.npmjs.org/repeat-string/1.6.1
-    dev: true
-
-  registry.npmjs.org/to-regex/3.0.2:
-    resolution: {integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz}
-    name: to-regex
-    version: 3.0.2
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      define-property: registry.npmjs.org/define-property/2.0.2
-      extend-shallow: registry.npmjs.org/extend-shallow/3.0.2
-      regex-not: registry.npmjs.org/regex-not/1.0.2
-      safe-regex: registry.npmjs.org/safe-regex/1.1.0
-    dev: true
-
-  registry.npmjs.org/trim-right/1.0.1:
-    resolution: {integrity: sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz}
-    name: trim-right
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  registry.npmjs.org/tsconfig-paths/3.11.0:
-    resolution: {integrity: sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz}
-    name: tsconfig-paths
-    version: 3.11.0
-    dependencies:
-      '@types/json5': registry.npmjs.org/@types/json5/0.0.29
-      json5: registry.npmjs.org/json5/1.0.1
-      minimist: registry.npmjs.org/minimist/1.2.5
-      strip-bom: registry.npmjs.org/strip-bom/3.0.0
-    dev: false
 
   registry.npmjs.org/type-check/0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz}
@@ -20517,38 +17144,15 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/unbox-primitive/1.0.1:
-    resolution: {integrity: sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz}
-    name: unbox-primitive
-    version: 1.0.1
-    dependencies:
-      function-bind: registry.npmjs.org/function-bind/1.1.1
-      has-bigints: registry.npmjs.org/has-bigints/1.0.1
-      has-symbols: registry.npmjs.org/has-symbols/1.0.2
-      which-boxed-primitive: registry.npmjs.org/which-boxed-primitive/1.0.2
-    dev: false
-
-  registry.npmjs.org/union-value/1.0.1:
-    resolution: {integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz}
-    name: union-value
-    version: 1.0.1
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      arr-union: registry.npmjs.org/arr-union/3.1.0
-      get-value: registry.npmjs.org/get-value/2.0.6
-      is-extendable: registry.npmjs.org/is-extendable/0.1.1
-      set-value: registry.npmjs.org/set-value/2.0.1
+  registry.npmjs.org/uglify-js/3.14.3:
+    resolution: {integrity: sha512-mic3aOdiq01DuSVx0TseaEzMIVqebMZ0Z3vaeDhFEh9bsc24hV1TFvN74reA2vs08D0ZWfNjAcJ3UbVLaBss+g==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.3.tgz}
+    name: uglify-js
+    version: 3.14.3
+    engines: {node: '>=0.8.0'}
+    hasBin: true
+    requiresBuild: true
     dev: true
-
-  registry.npmjs.org/unset-value/1.0.0:
-    resolution: {integrity: sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz}
-    name: unset-value
-    version: 1.0.0
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      has-value: registry.npmjs.org/has-value/0.3.1
-      isobject: registry.npmjs.org/isobject/3.0.1
-    dev: true
+    optional: true
 
   registry.npmjs.org/uri-js/4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz}
@@ -20556,25 +17160,8 @@ packages:
     version: 4.4.1
     dependencies:
       punycode: registry.npmjs.org/punycode/2.1.1
-
-  registry.npmjs.org/urix/0.1.0:
-    resolution: {integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/urix/-/urix-0.1.0.tgz}
-    name: urix
-    version: 0.1.0
-    dev: true
-
-  registry.npmjs.org/use/3.1.1:
-    resolution: {integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/use/-/use-3.1.1.tgz}
-    name: use
-    version: 3.1.1
-    engines: {node: '>=0.10.0'}
-    dev: true
-
-  registry.npmjs.org/util-deprecate/1.0.2:
-    resolution: {integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz}
-    name: util-deprecate
-    version: 1.0.2
-    dev: true
+    dev: false
+    optional: true
 
   registry.npmjs.org/v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz}
@@ -20583,53 +17170,15 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/vscode-json-languageservice/3.11.0:
-    resolution: {integrity: sha512-QxI+qV97uD7HHOCjh3MrM1TfbdwmTXrMckri5Tus1/FQiG3baDZb2C9Y0y8QThs7PwHYBIQXcAc59ZveCRZKPA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/vscode-json-languageservice/-/vscode-json-languageservice-3.11.0.tgz}
-    name: vscode-json-languageservice
-    version: 3.11.0
+  registry.npmjs.org/watchpack-chokidar2/2.0.1:
+    resolution: {integrity: sha512-nCFfBIPKr5Sh61s4LPpy1Wtfi0HE8isJ3d2Yb5/Ppw2P2B/3eVSEBjKfN0fmHJSK14+31KwMKmcrzs2GM4P0Ww==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.1.tgz}
+    name: watchpack-chokidar2
+    version: 2.0.1
+    requiresBuild: true
     dependencies:
-      jsonc-parser: registry.npmjs.org/jsonc-parser/3.0.0
-      vscode-languageserver-textdocument: registry.npmjs.org/vscode-languageserver-textdocument/1.0.2
-      vscode-languageserver-types: registry.npmjs.org/vscode-languageserver-types/3.16.0-next.2
-      vscode-nls: registry.npmjs.org/vscode-nls/5.0.0
-      vscode-uri: registry.npmjs.org/vscode-uri/2.1.2
-    dev: false
-
-  registry.npmjs.org/vscode-languageserver-textdocument/1.0.2:
-    resolution: {integrity: sha512-T7uPC18+f8mYE4lbVZwb3OSmvwTZm3cuFhrdx9Bn2l11lmp3SvSuSVjy2JtvrghzjAo4G6Trqny2m9XGnFnWVA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.2.tgz}
-    name: vscode-languageserver-textdocument
-    version: 1.0.2
-    dev: false
-
-  registry.npmjs.org/vscode-languageserver-types/3.16.0-next.2:
-    resolution: {integrity: sha512-QjXB7CKIfFzKbiCJC4OWC8xUncLsxo19FzGVp/ADFvvi87PlmBSCAtZI5xwGjF5qE0xkLf0jjKUn3DzmpDP52Q==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0-next.2.tgz}
-    name: vscode-languageserver-types
-    version: 3.16.0-next.2
-    dev: false
-
-  registry.npmjs.org/vscode-nls/5.0.0:
-    resolution: {integrity: sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz}
-    name: vscode-nls
-    version: 5.0.0
-    dev: false
-
-  registry.npmjs.org/vscode-uri/2.1.2:
-    resolution: {integrity: sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/vscode-uri/-/vscode-uri-2.1.2.tgz}
-    name: vscode-uri
-    version: 2.1.2
-    dev: false
-
-  registry.npmjs.org/which-boxed-primitive/1.0.2:
-    resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz}
-    name: which-boxed-primitive
-    version: 1.0.2
-    dependencies:
-      is-bigint: registry.npmjs.org/is-bigint/1.0.4
-      is-boolean-object: registry.npmjs.org/is-boolean-object/1.1.2
-      is-number-object: registry.npmjs.org/is-number-object/1.0.6
-      is-string: registry.npmjs.org/is-string/1.0.7
-      is-symbol: registry.npmjs.org/is-symbol/1.0.4
-    dev: false
+      chokidar: 2.1.8
+    dev: true
+    optional: true
 
   registry.npmjs.org/which/2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/which/-/which-2.0.2.tgz}
@@ -20650,17 +17199,12 @@ packages:
     dev: false
     optional: true
 
-  registry.npmjs.org/wordwrap/0.0.3:
-    resolution: {integrity: sha1-o9XabNXAvAAI03I0u68b7WMFkQc=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz}
-    name: wordwrap
-    version: 0.0.3
-    engines: {node: '>=0.4.0'}
-    dev: false
-
   registry.npmjs.org/wrappy/1.0.2:
     resolution: {integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz}
     name: wrappy
     version: 1.0.2
+    dev: false
+    optional: true
 
   registry.npmjs.org/yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==, registry: https://registry.myntra.com/, tarball: https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz}


### PR DESCRIPTION
# Bug 1 
## Reason 
- When running tests & building the packages ts was throwing an error around type incompatibility which broke the test suites & build.
- This happened because of the breaking changes in `@types/react v18`. Some of the packages import `@types/react` as a latest version which broke the build for existing apps.
## Reference
- https://stackoverflow.com/questions/71791347/npm-package-cannot-be-used-as-a-jsx-component-type-errors/71828113#71828113

# Warning 1
- During the build process, gettign warnings around deprecation warnings
## Reference
- https://sass-lang.com/documentation/breaking-changes/slash-div